### PR TITLE
added Check.InvalidArgument

### DIFF
--- a/Code/Light.GuardClauses.Performance/CommonAssertions/InvalidArgumentBenchmark.cs
+++ b/Code/Light.GuardClauses.Performance/CommonAssertions/InvalidArgumentBenchmark.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using BenchmarkDotNet.Attributes;
+
+namespace Light.GuardClauses.Performance.CommonAssertions
+{
+    public class InvalidArgumentBenchmark
+    {
+        public bool Condition = false;
+        public const string Message = "You must not call this method when Condition is true";
+        public const string ParameterName = "parameter";
+
+        [Benchmark(Baseline = true)]
+        public bool ImperativeVersion()
+        {
+            if (Condition) throw new ArgumentException(Message, ParameterName);
+            return Condition;
+        }
+
+        [Benchmark]
+        public bool LightGuardClauses()
+        {
+            Check.InvalidArgument(Condition, ParameterName, Message);
+            return Condition;
+        }
+
+        [Benchmark]
+        public bool LightGuardClausesCustomException()
+        {
+            Check.InvalidArgument(Condition, () => new ArgumentException(Message, ParameterName));
+            return Condition;
+        }
+
+        [Benchmark]
+        public bool LightGuardClausesCustomExceptionManualInlining()
+        {
+            if (Condition)
+                Exceptions.Throw.CustomException(() => new ArgumentException(Message, ParameterName));
+            return Condition;
+        }
+
+        [Benchmark]
+        public bool LightGuardClausesCustomExceptionWithParameter()
+        {
+            Check.InvalidArgument<string>(Condition, null, _ => new ArgumentException(Message, ParameterName));
+            return Condition;
+        }
+    }
+}

--- a/Code/Light.GuardClauses.Tests/CommonAssertions/InvalidArgumentTests.cs
+++ b/Code/Light.GuardClauses.Tests/CommonAssertions/InvalidArgumentTests.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using FluentAssertions;
+using Xunit;
+
+namespace Light.GuardClauses.Tests.CommonAssertions
+{
+    public static class InvalidArgumentTests
+    {
+        [Theory]
+        [MetasyntacticVariablesData]
+        public static void ConditionTrue(string parameterName)
+        {
+            Action act = () => Check.InvalidArgument(true, parameterName);
+
+            var exceptionAssertion = act.Should().Throw<ArgumentException>().And;
+            exceptionAssertion.ParamName.Should().BeSameAs(parameterName);
+            exceptionAssertion.Message.Should().Contain($"{parameterName} is invalid.");
+        }
+
+        [Fact]
+        public static void ConditionFalse()
+        {
+            Check.InvalidArgument(false);
+        }
+
+        [Fact]
+        public static void ConditionFalseCustomException()
+        {
+            Check.InvalidArgument(false, () => new Exception());
+        }
+
+        [Fact]
+        public static void ConditionFalseCustomExceptionWithParameter()
+        {
+            Check.InvalidArgument(false, new object(), _ => new Exception());
+        }
+
+        [Fact]
+        public static void CustomException() =>
+            Test.CustomException(exceptionFactory => Check.InvalidArgument(true, exceptionFactory));
+
+        [Fact]
+        public static void CustomExceptionWithParameter() =>
+            Test.CustomException(new object(),
+                                 (parameter, exceptionFactory) => Check.InvalidArgument(true, parameter, exceptionFactory));
+
+        [Fact]
+        public static void CustomMessage() =>
+            Test.CustomMessage<ArgumentException>(message => Check.InvalidArgument(true, message: message));
+
+        [Fact]
+        public static void DefaultMessage()
+        {
+            Action act = () => Check.InvalidArgument(true);
+
+            act.Should().Throw<ArgumentException>()
+               .And.Message.Should().Be("The value is invalid.");
+        }
+    }
+}

--- a/Code/Light.GuardClauses/Check.CommonAssertions.cs
+++ b/Code/Light.GuardClauses/Check.CommonAssertions.cs
@@ -323,6 +323,55 @@ namespace Light.GuardClauses
         }
 
         /// <summary>
+        /// Checks if the specified <paramref name="condition" /> is true and throws an <see cref="ArgumentException" /> in this case.
+        /// </summary>
+        /// <param name="condition">The condition to be checked. The exception is thrown when it is true.</param>
+        /// <param name="parameterName">The name of the parameter (optional).</param>
+        /// <param name="message">The message that will be passed to the <see cref="ArgumentException" /> (optional).</param>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="condition" /> is true.</exception>
+#if (NETSTANDARD2_0 || NETSTANDARD1_0 || NET45 || SILVERLIGHT)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public static void InvalidArgument(bool condition, string parameterName = null, string message = null)
+        {
+            if (condition)
+                Throw.Argument(parameterName, message);
+        }
+
+        /// <summary>
+        /// Checks if the specified <paramref name="condition" /> is true and throws your custom exception in this case.
+        /// </summary>
+        /// <param name="condition">The condition to be checked. The exception is thrown when it is true.</param>
+        /// <param name="exceptionFactory">The delegate that creates your custom exception.</param>
+        /// <exception cref="Exception">Your custom exception thrown when <paramref name="condition" /> is true.</exception>
+#if (NETSTANDARD2_0 || NETSTANDARD1_0 || NET45 || SILVERLIGHT)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        [ContractAnnotation("exceptionFactory:null => halt")]
+        public static void InvalidArgument(bool condition, Func<Exception> exceptionFactory)
+        {
+            if (condition)
+                Throw.CustomException(exceptionFactory);
+        }
+
+        /// <summary>
+        /// Checks if the specified <paramref name="condition" /> is true and throws your custom exception in this case.
+        /// </summary>
+        /// <param name="condition">The condition to be checked. The exception is thrown when it is true.</param>
+        /// <param name="parameter">The value that is checked in the <paramref name="condition"/>. This value is passed to the <paramref name="exceptionFactory"/>.</param>
+        /// <param name="exceptionFactory">The delegate that creates your custom exception. The <paramref name="parameter"/> is passed to this delegate.</param>
+        /// <exception cref="Exception">Your custom exception thrown when <paramref name="condition" /> is true.</exception>
+#if (NETSTANDARD2_0 || NETSTANDARD1_0 || NET45 || SILVERLIGHT)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        [ContractAnnotation("exceptionFactory:null => halt")]
+        public static void InvalidArgument<T>(bool condition, T parameter, Func<T, Exception> exceptionFactory)
+        {
+            if (condition)
+                Throw.CustomException(exceptionFactory, parameter);
+        }
+
+        /// <summary>
         /// Ensures that the specified nullable has a value and returns it, or otherwise throws a <see cref="NullableHasNoValueException" />.
         /// </summary>
         /// <param name="parameter">The nullable to be checked.</param>

--- a/Code/Light.GuardClauses/Exceptions/Throw.cs
+++ b/Code/Light.GuardClauses/Exceptions/Throw.cs
@@ -61,6 +61,13 @@ namespace Light.GuardClauses.Exceptions
         public static void InvalidState(string message = null) => throw new InvalidStateException(message);
 
         /// <summary>
+        /// Throws an <see cref="ArgumentException" /> using the optional parameter name and message.
+        /// </summary>
+        [ContractAnnotation("=> halt")]
+        public static void Argument(string parameterName = null, string message = null) =>
+            throw new ArgumentException(message ?? $"{parameterName ?? "The value"} is invalid.", parameterName);
+
+        /// <summary>
         /// Throws an <see cref="InvalidEmailAddressException"/> using the optional message.
         /// </summary>
         [ContractAnnotation("=> halt")]


### PR DESCRIPTION
# Description
Implements #64.

# Remarks
## Documentation
I had a bit of difficulty to meaningfully describe the `parameter` parameter in this overload:

    InvalidArgument<T>(bool condition, T parameter, Func<T, Exception> exceptionFactory)

In all other cases where we have a parameter value passed to the `exceptionFactory` this parameter value is as well checked by the guard method. In this case, the parameter value is not checked within the guard, but just the `condition`. Of course, we assume that the `condition` checks the `parameter`. Therefore I went for the following formulation:

`<param name="parameter">The value that is checked in the <paramref name="condition"/>. This value is passed to the <paramref name="exceptionFactory"/>.</param>`

## Performance
On my machine, the benchmarks are showing that the overloads with `exceptionFactory` are not inlined. In general, I had difficulties getting stable execution times in tests. But the ASM shows clear inlining in the first overload (without `exceptionFactory`). On the other hand, the [Inlining Analyzer](https://marketplace.visualstudio.com/items?itemName=StephanZehetner.InliningAnalyzer) shows that all the overloads should be inlined in benchmarks. Attached are results of two runs done on my laptop, in case you want to take a look.
[Benchmarks.zip](https://github.com/feO2x/Light.GuardClauses/files/3336552/Benchmarks.zip)

