### PR TITLE
Mark methods with NoEnumerationAttribute.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,6 +218,10 @@ ModelManifest.xml
 # TargetFrameworks.props files
 **/TargetFrameworks.props
 
+# JetBrains Rider
+*.sln.iml
+.idea/
+
 # The source code redistributable of Light.GuardClauses
 /Code/Light.GuardClauses.Source/Light.GuardClauses.cs
 /Code/Light.GuardClauses.SourceCodeTransformation/settings.json

--- a/Code/Light.GuardClauses/Check.CommonAssertions.cs
+++ b/Code/Light.GuardClauses/Check.CommonAssertions.cs
@@ -20,7 +20,7 @@ public static partial class Check
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="parameter" /> is null.</exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [ContractAnnotation("parameter:null => halt; parameter:notnull => notnull")]
-    public static T MustNotBeNull<T>([ValidatedNotNull] this T? parameter, [CallerArgumentExpression("parameter")] string? parameterName = null, string? message = null) where T : class
+    public static T MustNotBeNull<T>([ValidatedNotNull, NoEnumeration] this T? parameter, [CallerArgumentExpression("parameter")] string? parameterName = null, string? message = null) where T : class
     {
         if (parameter is null)
             Throw.ArgumentNull(parameterName, message);
@@ -35,7 +35,7 @@ public static partial class Check
     /// <exception cref="Exception">Your custom exception thrown when <paramref name="parameter" /> is null.</exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [ContractAnnotation("parameter:null => halt; parameter:notnull => notnull; exceptionFactory:null => halt")]
-    public static T MustNotBeNull<T>([ValidatedNotNull] this T? parameter, Func<Exception> exceptionFactory) where T : class
+    public static T MustNotBeNull<T>([ValidatedNotNull, NoEnumeration] this T? parameter, Func<Exception> exceptionFactory) where T : class
     {
         if (parameter is null)
             Throw.CustomException(exceptionFactory);
@@ -101,7 +101,7 @@ public static partial class Check
     /// <exception cref="ArgumentNullException">Thrown when <typeparamref name="T" /> is a reference type and <paramref name="parameter" /> is null.</exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [ContractAnnotation("parameter:null => halt; parameter:notnull => notnull")]
-    public static T MustNotBeNullReference<T>([ValidatedNotNull] this T parameter, [CallerArgumentExpression("parameter")] string? parameterName = null, string? message = null)
+    public static T MustNotBeNullReference<T>([ValidatedNotNull, NoEnumeration] this T parameter, [CallerArgumentExpression("parameter")] string? parameterName = null, string? message = null)
     {
         if (default(T) != null)
             return parameter;
@@ -121,7 +121,7 @@ public static partial class Check
     /// <exception cref="Exception">Your custom exception thrown when <typeparamref name="T" /> is a reference type and <paramref name="parameter" /> is null.</exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [ContractAnnotation("parameter:null => halt; parameter:notnull => notnull; exceptionFactory:null => halt")]
-    public static T MustNotBeNullReference<T>([ValidatedNotNull] this T parameter, Func<Exception> exceptionFactory)
+    public static T MustNotBeNullReference<T>([ValidatedNotNull, NoEnumeration] this T parameter, Func<Exception> exceptionFactory)
     {
         if (default(T) != null)
             return parameter;
@@ -359,7 +359,7 @@ public static partial class Check
     // ReSharper disable StringLiteralTypo
     [ContractAnnotation("parameter:notNull => true, other:notnull; parameter:notNull => false, other:canbenull; other:notnull => true, parameter:notnull; other:notnull => false, parameter:canbenull")]
     // ReSharper restore StringLiteralTypo
-    public static bool IsSameAs<T>(this T? parameter, T? other) where T : class =>
+    public static bool IsSameAs<T>([NoEnumeration] this T? parameter, [NoEnumeration] T? other) where T : class =>
         ReferenceEquals(parameter, other);
 
     /// <summary>
@@ -372,7 +372,7 @@ public static partial class Check
     /// <param name="message">The message that will be passed to the resulting exception (optional).</param>
     /// <exception cref="SameObjectReferenceException">Thrown when both <paramref name="parameter" /> and <paramref name="other" /> point to the same object.</exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static T? MustNotBeSameAs<T>(this T? parameter, T? other, [CallerArgumentExpression("parameter")] string? parameterName = null, string? message = null) where T : class
+    public static T? MustNotBeSameAs<T>([NoEnumeration] this T? parameter, [NoEnumeration] T? other, [CallerArgumentExpression("parameter")] string? parameterName = null, string? message = null) where T : class
     {
         if (ReferenceEquals(parameter, other))
             Throw.SameObjectReference(parameter, parameterName, message);
@@ -388,7 +388,7 @@ public static partial class Check
     /// <param name="exceptionFactory">The delegate that creates your custom exception. <paramref name="parameter" /> is passed to this delegate.</param>
     /// <exception cref="SameObjectReferenceException">Thrown when both <paramref name="parameter" /> and <paramref name="other" /> point to the same object.</exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static T? MustNotBeSameAs<T>(this T? parameter, T? other, Func<T?, Exception> exceptionFactory) where T : class
+    public static T? MustNotBeSameAs<T>([NoEnumeration] this T? parameter, T? other, Func<T?, Exception> exceptionFactory) where T : class
     {
         if (ReferenceEquals(parameter, other))
             Throw.CustomException(exceptionFactory, parameter);

--- a/Code/Light.GuardClauses/Check.CommonAssertions.cs
+++ b/Code/Light.GuardClauses/Check.CommonAssertions.cs
@@ -328,7 +328,7 @@ public static partial class Check
     /// <param name="message">The message that will be passed to the resulting exception (optional).</param>
     /// <exception cref="NullableHasNoValueException">Thrown when <paramref name="parameter" /> has no value.</exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static T MustHaveValue<T>(this T? parameter, [CallerArgumentExpression("parameter")] string? parameterName = null, string? message = null) where T : struct
+    public static T MustHaveValue<T>([NoEnumeration] this T? parameter, [CallerArgumentExpression("parameter")] string? parameterName = null, string? message = null) where T : struct
     {
         if (!parameter.HasValue)
             Throw.NullableHasNoValue(parameterName, message);
@@ -344,7 +344,7 @@ public static partial class Check
     /// <exception cref="NullableHasNoValueException">Thrown when <paramref name="parameter" /> has no value.</exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [ContractAnnotation("exceptionFactory:null => halt")]
-    public static T MustHaveValue<T>(this T? parameter, Func<Exception> exceptionFactory) where T : struct
+    public static T MustHaveValue<T>([NoEnumeration] this T? parameter, Func<Exception> exceptionFactory) where T : struct
     {
         if (!parameter.HasValue)
             Throw.CustomException(exceptionFactory);

--- a/Code/Light.GuardClauses/Check.CommonAssertions.cs
+++ b/Code/Light.GuardClauses/Check.CommonAssertions.cs
@@ -141,7 +141,7 @@ public static partial class Check
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="parameter" /> is null.</exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [ContractAnnotation("parameter:null => halt; parameter:notnull => notnull")]
-    public static T MustBeOfType<T>([ValidatedNotNull] this object? parameter, [CallerArgumentExpression("parameter")] string? parameterName = null, string? message = null)
+    public static T MustBeOfType<T>([ValidatedNotNull, NoEnumeration] this object? parameter, [CallerArgumentExpression("parameter")] string? parameterName = null, string? message = null)
     {
         if (parameter.MustNotBeNull(parameterName, message) is T castValue)
             return castValue;
@@ -158,7 +158,7 @@ public static partial class Check
     /// <exception cref="Exception">Your custom exception thrown when <paramref name="parameter" /> cannot be cast to <typeparamref name="T" />.</exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [ContractAnnotation("parameter:null => halt; parameter:notnull => notnull; exceptionFactory:null => halt")]
-    public static T MustBeOfType<T>([ValidatedNotNull] this object? parameter, Func<object?, Exception> exceptionFactory)
+    public static T MustBeOfType<T>([ValidatedNotNull, NoEnumeration] this object? parameter, Func<object?, Exception> exceptionFactory)
     {
         if (parameter is T castValue)
             return castValue;

--- a/Code/Light.GuardClauses/ReSharperAnnotations.cs
+++ b/Code/Light.GuardClauses/ReSharperAnnotations.cs
@@ -20,13 +20,21 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. */
 
+#nullable disable
+
 using System;
 // ReSharper disable CheckNamespace
+// ReSharper disable UnusedMember.Global
+// ReSharper disable MemberCanBePrivate.Global
+// ReSharper disable UnusedAutoPropertyAccessor.Global
+// ReSharper disable IntroduceOptionalParameters.Global
+// ReSharper disable MemberCanBeProtected.Global
+// ReSharper disable InconsistentNaming
 
 namespace JetBrains.Annotations;
 
 /// <summary>
-/// Indicates that the value of the marked element could never be <c>null</c>.
+/// Indicates that the value of the marked element can never be <c>null</c>.
 /// </summary>
 /// <example><code>
 /// [NotNull] object Foo() {
@@ -40,7 +48,7 @@ namespace JetBrains.Annotations;
 internal sealed class NotNullAttribute : Attribute { }
 
 /// <summary>
-/// Describes dependency between method input and output.
+/// Describes dependence between method input and output.
 /// </summary>
 /// <syntax>
 /// <p>Function Definition Table syntax:</p>
@@ -51,13 +59,13 @@ internal sealed class NotNullAttribute : Attribute { }
 /// <item>Output   ::= [ParameterName: Value]* {halt|stop|void|nothing|Value}</item>
 /// <item>Value    ::= true | false | null | notnull | canbenull</item>
 /// </list>
-/// If method has single input parameter, it's name could be omitted.<br/>
-/// Using <c>halt</c> (or <c>void</c>/<c>nothing</c>, which is the same) for method output
-/// means that the methos doesn't return normally (throws or terminates the process).<br/>
+/// If the method has a single input parameter, its name could be omitted.<br/>
+/// Using <c>halt</c> (or <c>void</c>/<c>nothing</c>, which is the same) for the method output
+/// means that the method doesn't return normally (throws or terminates the process).<br/>
 /// Value <c>canbenull</c> is only applicable for output parameters.<br/>
 /// You can use multiple <c>[ContractAnnotation]</c> for each FDT row, or use single attribute
-/// with rows separated by semicolon. There is no notion of order rows, all rows are checked
-/// for applicability and applied per each program state tracked by R# analysis.<br/>
+/// with rows separated by the semicolon. There is no notion of order rows, all rows are checked
+/// for applicability and applied per each program state tracked by the analysis engine.<br/>
 /// </syntax>
 /// <examples><list>
 /// <item><code>
@@ -65,8 +73,8 @@ internal sealed class NotNullAttribute : Attribute { }
 /// public void TerminationMethod()
 /// </code></item>
 /// <item><code>
-/// [ContractAnnotation("halt &lt;= condition: false")]
-/// public void Assert(bool condition, string text) // regular assertion method
+/// [ContractAnnotation("null &lt;= param:null")] // reverse condition syntax
+/// public string GetName(string surname)
 /// </code></item>
 /// <item><code>
 /// [ContractAnnotation("s:null =&gt; true")]
@@ -76,7 +84,7 @@ internal sealed class NotNullAttribute : Attribute { }
 /// // A method that returns null if the parameter is null,
 /// // and not null if the parameter is not null
 /// [ContractAnnotation("null =&gt; null; notnull =&gt; notnull")]
-/// public object Transform(object data) 
+/// public object Transform(object data)
 /// </code></item>
 /// <item><code>
 /// [ContractAnnotation("=&gt; true, result: notnull; =&gt; false, result: null")]
@@ -95,7 +103,26 @@ internal sealed class ContractAnnotationAttribute : Attribute
         ForceFullStates = forceFullStates;
     }
 
-    [NotNull] public string Contract { get; private set; }
+    [NotNull] public string Contract { get; }
 
-    public bool ForceFullStates { get; private set; }
+    public bool ForceFullStates { get; }
 }
+
+/// <summary>
+/// Indicates that IEnumerable passed as a parameter is not enumerated.
+/// Use this annotation to suppress the 'Possible multiple enumeration of IEnumerable' inspection.
+/// </summary>
+/// <example><code>
+/// static void ThrowIfNull&lt;T&gt;([NoEnumeration] T v, string n) where T : class
+/// {
+///   // custom check for null but no enumeration
+/// }
+///
+/// void Foo(IEnumerable&lt;string&gt; values)
+/// {
+///   ThrowIfNull(values, nameof(values));
+///   var x = values.ToList(); // No warnings about multiple enumeration
+/// }
+/// </code></example>
+[AttributeUsage(AttributeTargets.Parameter)]
+internal sealed class NoEnumerationAttribute : Attribute { }


### PR DESCRIPTION
## Description

Implements #82, which will stop JetBrains tools (ReSharper, Rider) from flagging non-enumerating methods as [Possible multiple enumeration of IEnumerable](https://www.jetbrains.com/help/resharper/PossibleMultipleEnumeration.html).