### PR TITLE
New workflow to automatically push to NuGet

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,9 +2,11 @@ name: Build and Test
 
 on:
   push:
-    branches: [ main, dev ]
+    branches: [main, dev]
+    paths: ['Code/**', 'build-and-test.yml']
   pull_request:
-    branches: [ main, dev ]
+    branches: [main, dev]
+    paths: ['Code/**', 'build-and-test.yml']
 
 jobs:
   build-and-test:
@@ -12,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 7.0.x
     - name: Restore dependencies

--- a/.github/workflows/release-on-nuget.yml
+++ b/.github/workflows/release-on-nuget.yml
@@ -4,18 +4,23 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      dotnetVersion:
+        description: "The version of .NET to use"
+        required: false
+        default: "7.0.x"
 
 jobs:
-  publish:
+  release-to-nuget:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: ${{ github.event.inputs.dotnetVersion || '7.0.x' }}
       - name: Prepare SNK file
         env:
           LIGHT_GUARDCLAUSES_SNK: ${{ secrets.LIGHT_GUARDCLAUSES_SNK }}
@@ -25,4 +30,7 @@ jobs:
         run: dotnet pack ./Code/Light.GuardClauses/Light.GuardClauses.csproj -c Release /p:SignAssembly=true /p:AssemblyOriginatorKeyFile=Light.GuardClauses.snk /p:ContinuousIntegrationBuild=true
       - name: Delete SNK file
         run: rm ./Code/Light.GuardClauses/Light.GuardClauses.snk
-      
+      - name: Push nupkg package
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: dotnet nuget push "./Code/Light.GuardClauses/bin/Release/Light.GuardClauses.*.nupkg" --api-key $NUGET_API_KEY --source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
Added new release-on-nuget.yml workflow which will automatically trigger when a release is published. It can also be triggered manually.

This PR also restricts the build-and-test.yml file to only execute when files in ./Code/ or the workflow itself was changed.