### PR TITLE
Native AOT

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 8.0.x
     - name: Restore dependencies
       run: dotnet restore ./Code/Light.GuardClauses.AllProjects.sln
     - name: Build Analyzer

--- a/.github/workflows/release-on-nuget.yml
+++ b/.github/workflows/release-on-nuget.yml
@@ -8,7 +8,7 @@ on:
       dotnetVersion:
         description: "The version of .NET to use"
         required: false
-        default: "7.0.x"
+        default: "8.0.x"
 
 jobs:
   release-to-nuget:
@@ -20,7 +20,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: ${{ github.event.inputs.dotnetVersion || '7.0.x' }}
+          dotnet-version: ${{ github.event.inputs.dotnetVersion || '8.0.x' }}
       - name: Prepare SNK file
         env:
           LIGHT_GUARDCLAUSES_SNK: ${{ secrets.LIGHT_GUARDCLAUSES_SNK }}

--- a/Code/Light.GuardClauses.Performance/CommonAssertions/MustBeValidEnumValueBenchmark.cs
+++ b/Code/Light.GuardClauses.Performance/CommonAssertions/MustBeValidEnumValueBenchmark.cs
@@ -35,7 +35,7 @@ namespace Light.GuardClauses.Performance.CommonAssertions
 
     public static class MustBeValidEnumValueExtensionMethods
     {
-        public static T OldMustBeValidEnumValue<T>(this T parameter, string parameterName = null, string message = null, Func<Exception> exception = null) where T : Enum
+        public static T OldMustBeValidEnumValue<T>(this T parameter, string parameterName = null, string message = null, Func<Exception> exception = null) where T : struct, Enum
         {
             if (parameter.IsValidEnumValue())
                 return parameter;

--- a/Code/Light.GuardClauses.Performance/Light.GuardClauses.Performance.csproj
+++ b/Code/Light.GuardClauses.Performance/Light.GuardClauses.Performance.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net7.0;net48</TargetFrameworks>
+        <TargetFrameworks>net8.0;net48</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Code/Light.GuardClauses.Tests/CommonAssertions/IsValidEnumValueTests.cs
+++ b/Code/Light.GuardClauses.Tests/CommonAssertions/IsValidEnumValueTests.cs
@@ -40,8 +40,8 @@ public static class IsValidEnumValueTests
     [InlineData(-2)]
     [InlineData(-512)]
     [InlineData(int.MinValue)]
-    [InlineData(1024)]
     [InlineData(2048)]
+    [InlineData(4096)]
     [InlineData(int.MaxValue)]
     public static void InvalidNumberStyles(int invalidValue) => ((NumberStyles) invalidValue).IsValidEnumValue().Should().BeFalse();
 

--- a/Code/Light.GuardClauses.Tests/CommonAssertions/IsValidEnumValueTests.cs
+++ b/Code/Light.GuardClauses.Tests/CommonAssertions/IsValidEnumValueTests.cs
@@ -20,7 +20,7 @@ public static class IsValidEnumValueTests
     [InlineData(UInt64Enum.AllLow | UInt64Enum.High1)]
     [InlineData(UInt64Enum.AllHigh)]
     [InlineData(UInt64Enum.MaxValue)]
-    public static void EnumValueValid<T>(T enumValue) where T : Enum, IComparable
+    public static void EnumValueValid<T>(T enumValue) where T : struct, Enum, IComparable
     {
         if (enumValue is BindingFlags)
         {

--- a/Code/Light.GuardClauses.Tests/CommonAssertions/MustNotBeEmptyGuidTests.cs
+++ b/Code/Light.GuardClauses.Tests/CommonAssertions/MustNotBeEmptyGuidTests.cs
@@ -46,4 +46,28 @@ public static class MustNotBeEmptyGuidTests
         act.Should().Throw<EmptyGuidException>()
            .And.ParamName.Should().Be(nameof(emptyGuid));
     }
+
+    public class Entity(Guid id)
+    {
+        public Guid Id { get; } = id.MustNotBeEmpty();
+    }
+    
+    [Fact]
+    public static void PrimaryConstructorValidArgument()
+    {
+        var guid = Guid.NewGuid();
+        var entity = new Entity(guid);
+
+        entity.Id.Should().Be(guid);
+    }
+
+    [Fact]
+    public static void PrimaryConstructorInvalidArgument()
+    {
+        var act = () => new Entity(Guid.Empty);
+
+        act.Should().Throw<EmptyGuidException>()
+           .And.Message.Should().StartWith("id must be a valid GUID, but it actually is an empty one.");
+    }
 }
+

--- a/Code/Light.GuardClauses.Tests/FrameworkExtensions/AsListTests.cs
+++ b/Code/Light.GuardClauses.Tests/FrameworkExtensions/AsListTests.cs
@@ -44,12 +44,12 @@ public static class AsListTests
     public static void ReturnsNewListIfCastNotPossible()
     {
         // ReSharper disable PossibleMultipleEnumeration
-        var enumerable = Enumerable.Range(1, 5);
+        var enumerable = LazyEnumerable();
 
         var list = enumerable.AsList();
 
         list.Should().NotBeSameAs(enumerable);
-        list.Should().BeOfType<List<int>>();
+        list.Should().BeOfType<List<string>>();
         list.Should().Equal(enumerable);
         // ReSharper restore PossibleMultipleEnumeration
     }

--- a/Code/Light.GuardClauses.Tests/FrameworkExtensions/AsReadOnlyListTests.cs
+++ b/Code/Light.GuardClauses.Tests/FrameworkExtensions/AsReadOnlyListTests.cs
@@ -44,12 +44,12 @@ public static class AsReadOnlyListTests
     public static void ReturnsNewListIfCastNotPossible()
     {
         // ReSharper disable PossibleMultipleEnumeration
-        var enumerable = Enumerable.Range(1, 5);
+        var enumerable = LazyEnumerable();
 
         var list = enumerable.AsReadOnlyList();
 
         list.Should().NotBeSameAs(enumerable);
-        list.Should().BeOfType<List<int>>();
+        list.Should().BeOfType<List<string>>();
         list.Should().Equal(enumerable);
         // ReSharper restore PossibleMultipleEnumeration
     }

--- a/Code/Light.GuardClauses.Tests/Light.GuardClauses.Tests.csproj
+++ b/Code/Light.GuardClauses.Tests/Light.GuardClauses.Tests.csproj
@@ -3,16 +3,16 @@
     <Import Project="TargetFrameworks.props" Condition="Exists('TargetFrameworks.props')" />
 
     <PropertyGroup>
-        <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net7.0</TargetFrameworks>
+        <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
-        <LangVersion>11.0</LangVersion>
+        <LangVersion>12</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
-        <PackageReference Include="FluentAssertions" Version="6.11.0" />
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+        <PackageReference Include="FluentAssertions" Version="6.12.0" />
+        <PackageReference Include="xunit" Version="2.5.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
         <ProjectReference Include="..\Light.GuardClauses\Light.GuardClauses.csproj" />
     </ItemGroup>
 

--- a/Code/Light.GuardClauses/CallerArgumentExpressionAttribute.cs
+++ b/Code/Light.GuardClauses/CallerArgumentExpressionAttribute.cs
@@ -1,4 +1,5 @@
-﻿// ReSharper disable once CheckNamespace -- CallerArgumentExpression must be in exactly this namespace
+﻿#if !NET8_0
+// ReSharper disable once CheckNamespace -- CallerArgumentExpression must be in exactly this namespace
 namespace System.Runtime.CompilerServices;
 
 [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
@@ -11,3 +12,4 @@ internal sealed class CallerArgumentExpressionAttribute : Attribute
 
     public string ParameterName { get; }
 }
+#endif

--- a/Code/Light.GuardClauses/Check.CommonAssertions.cs
+++ b/Code/Light.GuardClauses/Check.CommonAssertions.cs
@@ -175,7 +175,7 @@ public static partial class Check
     /// <typeparam name="T">The type of the enum.</typeparam>
     /// <param name="parameter">The enum value to be checked.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool IsValidEnumValue<T>(this T parameter) where T : Enum
+    public static bool IsValidEnumValue<T>(this T parameter) where T : struct, Enum
         => EnumInfo<T>.IsValidEnumValue(parameter);
 
     /// <summary>
@@ -189,7 +189,7 @@ public static partial class Check
     /// <param name="message">The message that will be passed to the resulting exception (optional).</param>
     /// <exception cref="EnumValueNotDefinedException">Thrown when <paramref name="parameter" /> is no valid enum value.</exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static T MustBeValidEnumValue<T>(this T parameter, [CallerArgumentExpression("parameter")] string? parameterName = null, string? message = null) where T : Enum
+    public static T MustBeValidEnumValue<T>(this T parameter, [CallerArgumentExpression("parameter")] string? parameterName = null, string? message = null) where T : struct, Enum
     {
         if (!EnumInfo<T>.IsValidEnumValue(parameter))
             Throw.EnumValueNotDefined(parameter, parameterName, message);
@@ -207,7 +207,7 @@ public static partial class Check
     /// <exception cref="Exception">Your custom exception thrown when <paramref name="parameter" /> is no valid enum value, or when <typeparamref name="T" /> is no enum type.</exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [ContractAnnotation("exceptionFactory:null => halt")]
-    public static T MustBeValidEnumValue<T>(this T parameter, Func<T, Exception> exceptionFactory) where T : Enum
+    public static T MustBeValidEnumValue<T>(this T parameter, Func<T, Exception> exceptionFactory) where T : struct, Enum
     {
         if (!EnumInfo<T>.IsValidEnumValue(parameter))
             Throw.CustomException(exceptionFactory, parameter);

--- a/Code/Light.GuardClauses/Check.TypeAssertions.cs
+++ b/Code/Light.GuardClauses/Check.TypeAssertions.cs
@@ -2,6 +2,9 @@
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
+#if NET8_0
+using System.Diagnostics.CodeAnalysis;
+#endif
 
 namespace Light.GuardClauses;
 
@@ -41,11 +44,19 @@ public static partial class Check
     /// <param name="interfaceType">The interface type that <paramref name="type" /> should implement.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="type" /> or <paramref name="interfaceType" /> is null.</exception>
     [ContractAnnotation("type:null => halt; interfaceType:null => halt")]
-    public static bool Implements([ValidatedNotNull] this Type type, [ValidatedNotNull] Type interfaceType)
+    public static bool Implements(
+#if NET8_0
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
+#endif
+        [ValidatedNotNull]
+        this Type type,
+        [ValidatedNotNull] Type interfaceType
+    )
     {
-        interfaceType.MustNotBeNull(nameof(interfaceType));
-        var implementedInterfaces = type.MustNotBeNull(nameof(type)).GetInterfaces();
+        type.MustNotBeNull();
+        interfaceType.MustNotBeNull();
 
+        var implementedInterfaces = type.GetInterfaces();
         for (var i = 0; i < implementedInterfaces.Length; ++i)
         {
             if (interfaceType.IsEquivalentTypeTo(implementedInterfaces[i]))
@@ -64,12 +75,21 @@ public static partial class Check
     /// <param name="typeComparer">The equality comparer used to compare the interface types.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="type" />, or <paramref name="interfaceType" />, or <paramref name="typeComparer" /> is null.</exception>
     [ContractAnnotation("type:null => halt; interfaceType:null => halt; typeComparer:null => halt")]
-    public static bool Implements([ValidatedNotNull] this Type type, [ValidatedNotNull] Type interfaceType, [ValidatedNotNull] IEqualityComparer<Type> typeComparer)
+    public static bool Implements(
+#if NET8_0
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
+#endif
+        [ValidatedNotNull]
+        this Type type,
+        [ValidatedNotNull] Type interfaceType,
+        [ValidatedNotNull] IEqualityComparer<Type> typeComparer
+    )
     {
-        interfaceType.MustNotBeNull(nameof(interfaceType));
-        typeComparer.MustNotBeNull(nameof(typeComparer));
+        type.MustNotBeNull();
+        interfaceType.MustNotBeNull();
+        typeComparer.MustNotBeNull();
 
-        var implementedInterfaces = type.MustNotBeNull(nameof(type)).GetInterfaces();
+        var implementedInterfaces = type.GetInterfaces();
         for (var i = 0; i < implementedInterfaces.Length; ++i)
         {
             if (typeComparer.Equals(implementedInterfaces[i], interfaceType))
@@ -88,7 +108,12 @@ public static partial class Check
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="type" /> or <paramref name="otherType" /> is null.</exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [ContractAnnotation("type:null => halt; otherType:null => halt")]
-    public static bool IsOrImplements([ValidatedNotNull] this Type type, [ValidatedNotNull] Type otherType) =>
+    public static bool IsOrImplements(
+#if NET8_0
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
+#endif
+        [ValidatedNotNull] this Type type,
+        [ValidatedNotNull] Type otherType) =>
         type.IsEquivalentTypeTo(otherType.MustNotBeNull(nameof(otherType))) || type.Implements(otherType);
 
     /// <summary>
@@ -102,7 +127,13 @@ public static partial class Check
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="type" /> or <paramref name="otherType" /> is null.</exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [ContractAnnotation("type:null => halt; otherType:null => halt")]
-    public static bool IsOrImplements([ValidatedNotNull] this Type type, [ValidatedNotNull] Type otherType, [ValidatedNotNull] IEqualityComparer<Type> typeComparer) =>
+    public static bool IsOrImplements(
+#if NET8_0
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
+#endif
+        [ValidatedNotNull] this Type type,
+        [ValidatedNotNull] Type otherType,
+        [ValidatedNotNull] IEqualityComparer<Type> typeComparer) =>
         typeComparer.MustNotBeNull(nameof(typeComparer)).Equals(type.MustNotBeNull(nameof(type)), otherType.MustNotBeNull(nameof(otherType))) || type.Implements(otherType, typeComparer);
 
     /// <summary>
@@ -190,11 +221,16 @@ public static partial class Check
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="type" /> or <paramref name="baseClassOrInterfaceType" /> is null.</exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [ContractAnnotation("type:null => halt; baseClassOrInterfaceType:null => halt")]
-    public static bool InheritsFrom([ValidatedNotNull] this Type type, [ValidatedNotNull] Type baseClassOrInterfaceType) =>
+    public static bool InheritsFrom(
+#if NET8_0
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
+#endif        
+        [ValidatedNotNull] this Type type,
+        [ValidatedNotNull] Type baseClassOrInterfaceType) =>
         baseClassOrInterfaceType.MustNotBeNull(nameof(baseClassOrInterfaceType))
-                                .IsInterface
-            ? type.Implements(baseClassOrInterfaceType)
-            : type.DerivesFrom(baseClassOrInterfaceType);
+                                .IsInterface ?
+            type.Implements(baseClassOrInterfaceType) :
+            type.DerivesFrom(baseClassOrInterfaceType);
 
     /// <summary>
     /// Checks if the given type derives from the specified base class or interface type. This overload uses the specified <paramref name="typeComparer" />
@@ -206,11 +242,17 @@ public static partial class Check
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="type" />, or <paramref name="baseClassOrInterfaceType" />, or <paramref name="typeComparer" /> is null.</exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [ContractAnnotation("type:null => halt; baseClassOrInterfaceType:null => halt; typeComparer:null => halt")]
-    public static bool InheritsFrom([ValidatedNotNull] this Type type, [ValidatedNotNull] Type baseClassOrInterfaceType, [ValidatedNotNull] IEqualityComparer<Type> typeComparer) =>
+    public static bool InheritsFrom(
+#if NET8_0
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
+#endif        
+        [ValidatedNotNull] this Type type,
+        [ValidatedNotNull] Type baseClassOrInterfaceType,
+        [ValidatedNotNull] IEqualityComparer<Type> typeComparer) =>
         baseClassOrInterfaceType.MustNotBeNull(nameof(baseClassOrInterfaceType))
-                                .IsInterface
-            ? type.Implements(baseClassOrInterfaceType, typeComparer)
-            : type.DerivesFrom(baseClassOrInterfaceType, typeComparer);
+                                .IsInterface ?
+            type.Implements(baseClassOrInterfaceType, typeComparer) :
+            type.DerivesFrom(baseClassOrInterfaceType, typeComparer);
 
     /// <summary>
     /// Checks if the given <paramref name="type" /> is equal to the specified <paramref name="otherType" /> or if it derives from it or implements it.
@@ -222,7 +264,12 @@ public static partial class Check
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="type" /> or <paramref name="otherType" /> is null.</exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [ContractAnnotation("type:null => halt; otherType:null => halt")]
-    public static bool IsOrInheritsFrom([ValidatedNotNull] this Type type, [ValidatedNotNull] Type otherType) =>
+    public static bool IsOrInheritsFrom(
+#if NET8_0
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
+#endif
+        [ValidatedNotNull] this Type type,
+        [ValidatedNotNull] Type otherType) =>
         type.IsEquivalentTypeTo(otherType.MustNotBeNull(nameof(otherType))) || type.InheritsFrom(otherType);
 
 
@@ -236,7 +283,13 @@ public static partial class Check
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="type" /> or <paramref name="otherType" /> is null.</exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [ContractAnnotation("type:null => halt; otherType:null => halt; typeComparer:null => halt")]
-    public static bool IsOrInheritsFrom([ValidatedNotNull] this Type type, [ValidatedNotNull] Type otherType, [ValidatedNotNull] IEqualityComparer<Type> typeComparer) =>
+    public static bool IsOrInheritsFrom(
+#if NET8_0
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
+#endif        
+        [ValidatedNotNull] this Type type,
+        [ValidatedNotNull] Type otherType,
+        [ValidatedNotNull] IEqualityComparer<Type> typeComparer) =>
         typeComparer.MustNotBeNull(nameof(typeComparer)).Equals(type, otherType.MustNotBeNull(nameof(otherType))) || type.InheritsFrom(otherType, typeComparer);
 
 

--- a/Code/Light.GuardClauses/EnumInfo.cs
+++ b/Code/Light.GuardClauses/EnumInfo.cs
@@ -10,7 +10,7 @@ namespace Light.GuardClauses;
 /// Can be used to validate that an enum value is valid.
 /// </summary>
 /// <typeparam name="T">The type of the enum.</typeparam>
-public static class EnumInfo<T> where T : Enum
+public static class EnumInfo<T> where T : struct, Enum
 {
     // ReSharper disable StaticMemberInGenericType
 
@@ -29,22 +29,18 @@ public static class EnumInfo<T> where T : Enum
     private static readonly T[] EnumConstantsArray;
 
     /// <summary>
-    /// Gets the underlying type that is used for the enum (<see cref="int" /> for default enums).
-    /// </summary>
-    public static readonly Type UnderlyingType;
-
-    /// <summary>
     /// Gets the values of the enum as a read-only collection.
     /// </summary>
     public static ReadOnlyMemory<T> EnumConstants { get; }
 
     static EnumInfo()
     {
+#if NET8_0
+        EnumConstantsArray = Enum.GetValues<T>();
+#else
         EnumConstantsArray = (T[]) Enum.GetValues(typeof(T));
-        var fields = typeof(T).GetFields();
-
-        UnderlyingType = fields[0].FieldType;
-        EnumConstants = new ReadOnlyMemory<T>(EnumConstantsArray);
+#endif
+        EnumConstants = new (EnumConstantsArray);
 
         if (!IsFlagsEnum)
             return;

--- a/Code/Light.GuardClauses/Exceptions/AbsoluteUriException.cs
+++ b/Code/Light.GuardClauses/Exceptions/AbsoluteUriException.cs
@@ -16,6 +16,8 @@ public class AbsoluteUriException : UriException
     /// <param name="message">The message of the exception (optional).</param>
     public AbsoluteUriException(string? parameterName = null, string? message = null) : base(parameterName, message) { }
 
+#if !NET8_0
     /// <inheritdoc />
     protected AbsoluteUriException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+#endif
 }

--- a/Code/Light.GuardClauses/Exceptions/ArgumentDefaultException.cs
+++ b/Code/Light.GuardClauses/Exceptions/ArgumentDefaultException.cs
@@ -16,6 +16,8 @@ public class ArgumentDefaultException : ArgumentException
     /// <param name="message">The message of the exception (optional).</param>
     public ArgumentDefaultException(string? parameterName = null, string? message = null) : base(message, parameterName) { }
 
+#if !NET8_0
     /// <inheritdoc />
     protected ArgumentDefaultException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+#endif
 }

--- a/Code/Light.GuardClauses/Exceptions/CollectionException.cs
+++ b/Code/Light.GuardClauses/Exceptions/CollectionException.cs
@@ -16,6 +16,8 @@ public class CollectionException : ArgumentException
     /// <param name="message">The message of the exception (optional).</param>
     public CollectionException(string? parameterName = null, string? message = null) : base(message, parameterName) { }
 
+#if !NET8_0
     /// <inheritdoc />
     protected CollectionException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+#endif
 }

--- a/Code/Light.GuardClauses/Exceptions/EmptyCollectionException.cs
+++ b/Code/Light.GuardClauses/Exceptions/EmptyCollectionException.cs
@@ -16,6 +16,8 @@ public class EmptyCollectionException : InvalidCollectionCountException
     /// <param name="message">The message of the exception (optional).</param>
     public EmptyCollectionException(string? parameterName = null, string? message = null) : base(parameterName, message) { }
 
+#if !NET8_0
     /// <inheritdoc />
     protected EmptyCollectionException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+#endif
 }

--- a/Code/Light.GuardClauses/Exceptions/EmptyGuidException.cs
+++ b/Code/Light.GuardClauses/Exceptions/EmptyGuidException.cs
@@ -16,6 +16,8 @@ public class EmptyGuidException : ArgumentException
     /// <param name="message">The message of the exception (optional).</param>
     public EmptyGuidException(string? parameterName = null, string? message = null) : base(message, parameterName) { }
 
+#if !NET8_0
     /// <inheritdoc />
     protected EmptyGuidException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+#endif
 }

--- a/Code/Light.GuardClauses/Exceptions/EmptyStringException.cs
+++ b/Code/Light.GuardClauses/Exceptions/EmptyStringException.cs
@@ -16,6 +16,8 @@ public class EmptyStringException : StringException
     /// <param name="message">The message of the exception (optional).</param>
     public EmptyStringException(string? parameterName = null, string? message = null) : base(parameterName, message) { }
 
+#if !NET8_0
     /// <inheritdoc />
     protected EmptyStringException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+#endif
 }

--- a/Code/Light.GuardClauses/Exceptions/EnumValueNotDefinedException.cs
+++ b/Code/Light.GuardClauses/Exceptions/EnumValueNotDefinedException.cs
@@ -16,6 +16,8 @@ public class EnumValueNotDefinedException : ArgumentException
     /// <param name="message">The message of the exception.</param>
     public EnumValueNotDefinedException(string? parameterName = null, string? message = null) : base(message, parameterName) { }
 
+#if !NET8_0
     /// <inheritdoc />
     protected EnumValueNotDefinedException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+#endif
 }

--- a/Code/Light.GuardClauses/Exceptions/ExistingItemException.cs
+++ b/Code/Light.GuardClauses/Exceptions/ExistingItemException.cs
@@ -16,6 +16,8 @@ public class ExistingItemException : CollectionException
     /// <param name="message">The message of the exception (optional).</param>
     public ExistingItemException(string? parameterName = null, string? message = null) : base(parameterName, message) { }
 
+#if !NET8_0
     /// <inheritdoc />
     protected ExistingItemException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+#endif
 }

--- a/Code/Light.GuardClauses/Exceptions/InvalidCollectionCountException.cs
+++ b/Code/Light.GuardClauses/Exceptions/InvalidCollectionCountException.cs
@@ -16,6 +16,8 @@ public class InvalidCollectionCountException : CollectionException
     /// <param name="message">The message of the exception (optional).</param>
     public InvalidCollectionCountException(string? parameterName = null, string? message = null) : base(parameterName, message) { }
 
+#if !NET8_0
     /// <inheritdoc />
     protected InvalidCollectionCountException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+#endif
 }

--- a/Code/Light.GuardClauses/Exceptions/InvalidConfigurationException.cs
+++ b/Code/Light.GuardClauses/Exceptions/InvalidConfigurationException.cs
@@ -16,6 +16,8 @@ public class InvalidConfigurationException : Exception
     /// <param name="innerException">The exception that is the cause of this one (optional).</param>
     public InvalidConfigurationException(string? message = null, Exception? innerException = null) : base(message, innerException) { }
 
+#if !NET8_0
     /// <inheritdoc />
     protected InvalidConfigurationException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+#endif
 }

--- a/Code/Light.GuardClauses/Exceptions/InvalidDateTimeException.cs
+++ b/Code/Light.GuardClauses/Exceptions/InvalidDateTimeException.cs
@@ -4,7 +4,7 @@ using System.Runtime.Serialization;
 namespace Light.GuardClauses.Exceptions;
 
 /// <summary>
-/// This exception indicates that a <see cref="DateTime"/> value is invalid.
+/// This exception indicates that a <see cref="DateTime" /> value is invalid.
 /// </summary>
 [Serializable]
 public class InvalidDateTimeException : ArgumentException
@@ -16,6 +16,8 @@ public class InvalidDateTimeException : ArgumentException
     /// <param name="message">The message of the exception (optional).</param>
     public InvalidDateTimeException(string? parameterName = null, string? message = null) : base(message, parameterName) { }
 
+#if !NET8_0
     /// <inheritdoc />
     protected InvalidDateTimeException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+#endif
 }

--- a/Code/Light.GuardClauses/Exceptions/InvalidEmailAddressException.cs
+++ b/Code/Light.GuardClauses/Exceptions/InvalidEmailAddressException.cs
@@ -16,6 +16,8 @@ public class InvalidEmailAddressException : StringException
     /// <param name="message">The message of the exception (optional).</param>
     public InvalidEmailAddressException(string? parameterName = null, string? message = null) : base(parameterName, message) { }
 
+#if !NET8_0
     /// <inheritdoc />
     protected InvalidEmailAddressException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+#endif
 }

--- a/Code/Light.GuardClauses/Exceptions/InvalidStateException.cs
+++ b/Code/Light.GuardClauses/Exceptions/InvalidStateException.cs
@@ -16,6 +16,8 @@ public class InvalidStateException : Exception
     /// <param name="innerException">The exception that is the cause of this one (optional).</param>
     public InvalidStateException(string? message = null, Exception? innerException = null) : base(message, innerException) { }
 
+#if !NET8_0
     /// <inheritdoc />
     protected InvalidStateException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+#endif
 }

--- a/Code/Light.GuardClauses/Exceptions/InvalidUriSchemeException.cs
+++ b/Code/Light.GuardClauses/Exceptions/InvalidUriSchemeException.cs
@@ -16,6 +16,8 @@ public class InvalidUriSchemeException : UriException
     /// <param name="message">The message of the exception (optional).</param>
     public InvalidUriSchemeException(string? parameterName = null, string? message = null) : base(parameterName, message) { }
 
+#if !NET8_0
     /// <inheritdoc />
     protected InvalidUriSchemeException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+#endif
 }

--- a/Code/Light.GuardClauses/Exceptions/MissingItemException.cs
+++ b/Code/Light.GuardClauses/Exceptions/MissingItemException.cs
@@ -16,6 +16,8 @@ public class MissingItemException : CollectionException
     /// <param name="message">The message of the exception (optional).</param>
     public MissingItemException(string? parameterName = null, string? message = null) : base(parameterName, message) { }
 
+#if !NET8_0
     /// <inheritdoc />
     protected MissingItemException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+#endif
 }

--- a/Code/Light.GuardClauses/Exceptions/NullableHasNoValueException.cs
+++ b/Code/Light.GuardClauses/Exceptions/NullableHasNoValueException.cs
@@ -4,7 +4,7 @@ using System.Runtime.Serialization;
 namespace Light.GuardClauses.Exceptions;
 
 /// <summary>
-/// This exception indicates that a <see cref="Nullable{T}"/> has no value.
+/// This exception indicates that a <see cref="Nullable{T}" /> has no value.
 /// </summary>
 [Serializable]
 public class NullableHasNoValueException : ArgumentException
@@ -16,6 +16,8 @@ public class NullableHasNoValueException : ArgumentException
     /// <param name="message">The message of the exception (optional).</param>
     public NullableHasNoValueException(string? parameterName = null, string? message = null) : base(message, parameterName) { }
 
+#if !NET8_0
     /// <inheritdoc />
     protected NullableHasNoValueException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+#endif
 }

--- a/Code/Light.GuardClauses/Exceptions/RelativeUriException.cs
+++ b/Code/Light.GuardClauses/Exceptions/RelativeUriException.cs
@@ -16,6 +16,8 @@ public class RelativeUriException : UriException
     /// <param name="message">The message of the exception (optional).</param>
     public RelativeUriException(string? parameterName = null, string? message = null) : base(parameterName, message) { }
 
+#if !NET8_0
     /// <inheritdoc />
     protected RelativeUriException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+#endif
 }

--- a/Code/Light.GuardClauses/Exceptions/SameObjectReferenceException.cs
+++ b/Code/Light.GuardClauses/Exceptions/SameObjectReferenceException.cs
@@ -16,6 +16,8 @@ public class SameObjectReferenceException : ArgumentException
     /// <param name="message">The message of the exception (optional).</param>
     public SameObjectReferenceException(string? parameterName = null, string? message = null) : base(message, parameterName) { }
 
+#if !NET8_0
     /// <inheritdoc />
     protected SameObjectReferenceException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+#endif
 }

--- a/Code/Light.GuardClauses/Exceptions/StringDoesNotMatchException.cs
+++ b/Code/Light.GuardClauses/Exceptions/StringDoesNotMatchException.cs
@@ -16,6 +16,8 @@ public class StringDoesNotMatchException : StringException
     /// <param name="message">The message of the exception (optional).</param>
     public StringDoesNotMatchException(string? parameterName = null, string? message = null) : base(parameterName, message) { }
 
+#if !NET8_0
     /// <inheritdoc />
     protected StringDoesNotMatchException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+#endif
 }

--- a/Code/Light.GuardClauses/Exceptions/StringException.cs
+++ b/Code/Light.GuardClauses/Exceptions/StringException.cs
@@ -16,6 +16,8 @@ public class StringException : ArgumentException
     /// <param name="message">The message of the exception (optional).</param>
     public StringException(string? parameterName = null, string? message = null) : base(message, parameterName) { }
 
+#if !NET8_0
     /// <inheritdoc />
     protected StringException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+#endif
 }

--- a/Code/Light.GuardClauses/Exceptions/StringLengthException.cs
+++ b/Code/Light.GuardClauses/Exceptions/StringLengthException.cs
@@ -16,6 +16,8 @@ public class StringLengthException : StringException
     /// <param name="message">The message of the exception (optional).</param>
     public StringLengthException(string? parameterName = null, string? message = null) : base(parameterName, message) { }
 
+#if !NET8_0
     /// <inheritdoc />
     protected StringLengthException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+#endif
 }

--- a/Code/Light.GuardClauses/Exceptions/SubstringException.cs
+++ b/Code/Light.GuardClauses/Exceptions/SubstringException.cs
@@ -16,6 +16,8 @@ public class SubstringException : StringException
     /// <param name="message">The message of the exception (optional).</param>
     public SubstringException(string? parameterName = null, string? message = null) : base(parameterName, message) { }
 
+#if !NET8_0
     /// <inheritdoc />
     protected SubstringException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+#endif
 }

--- a/Code/Light.GuardClauses/Exceptions/TypeCastException.cs
+++ b/Code/Light.GuardClauses/Exceptions/TypeCastException.cs
@@ -16,6 +16,8 @@ public class TypeCastException : ArgumentException
     /// <param name="message">The message of the exception (optional).</param>
     public TypeCastException(string? parameterName = null, string? message = null) : base(message, parameterName) { }
 
+#if !NET8_0
     /// <inheritdoc />
     protected TypeCastException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+#endif
 }

--- a/Code/Light.GuardClauses/Exceptions/UriException.cs
+++ b/Code/Light.GuardClauses/Exceptions/UriException.cs
@@ -16,6 +16,8 @@ public class UriException : ArgumentException
     /// <param name="message">The message of the exception (optional).</param>
     public UriException(string? parameterName = null, string? message = null) : base(message, parameterName) { }
 
+#if !NET8_0
     /// <inheritdoc />
     protected UriException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+#endif
 }

--- a/Code/Light.GuardClauses/Exceptions/ValueIsNotOneOfException.cs
+++ b/Code/Light.GuardClauses/Exceptions/ValueIsNotOneOfException.cs
@@ -16,6 +16,8 @@ public class ValueIsNotOneOfException : ArgumentException
     /// <param name="message">The message of the exception (optional).</param>
     public ValueIsNotOneOfException(string? parameterName = null, string? message = null) : base(message, parameterName) { }
 
+#if !NET8_0
     /// <inheritdoc />
     protected ValueIsNotOneOfException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+#endif
 }

--- a/Code/Light.GuardClauses/Exceptions/ValueIsOneOfException.cs
+++ b/Code/Light.GuardClauses/Exceptions/ValueIsOneOfException.cs
@@ -16,6 +16,8 @@ public class ValueIsOneOfException : ArgumentException
     /// <param name="message">The message of the exception (optional).</param>
     public ValueIsOneOfException(string? parameterName = null, string? message = null) : base(message, parameterName) { }
 
+#if !NET8_0
     /// <inheritdoc />
     protected ValueIsOneOfException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+#endif
 }

--- a/Code/Light.GuardClauses/Exceptions/ValuesEqualException.cs
+++ b/Code/Light.GuardClauses/Exceptions/ValuesEqualException.cs
@@ -16,6 +16,8 @@ public class ValuesEqualException : ArgumentException
     /// <param name="message">The message of the exception (optional).</param>
     public ValuesEqualException(string? parameterName = null, string? message = null) : base(message, parameterName) { }
 
+#if !NET8_0
     /// <inheritdoc />
     protected ValuesEqualException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+#endif
 }

--- a/Code/Light.GuardClauses/Exceptions/ValuesNotEqualException.cs
+++ b/Code/Light.GuardClauses/Exceptions/ValuesNotEqualException.cs
@@ -16,6 +16,8 @@ public class ValuesNotEqualException : ArgumentException
     /// <param name="message">The message of the exception (optional).</param>
     public ValuesNotEqualException(string? parameterName = null, string? message = null) : base(message, parameterName) { }
 
+#if !NET8_0
     /// <inheritdoc />
     protected ValuesNotEqualException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+#endif
 }

--- a/Code/Light.GuardClauses/Exceptions/WhiteSpaceStringException.cs
+++ b/Code/Light.GuardClauses/Exceptions/WhiteSpaceStringException.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Runtime.Serialization;
 
-
 namespace Light.GuardClauses.Exceptions;
 
 /// <summary>
@@ -17,6 +16,8 @@ public class WhiteSpaceStringException : StringException
     /// <param name="message">The message of the exception (optional).</param>
     public WhiteSpaceStringException(string? parameterName = null, string? message = null) : base(parameterName, message) { }
 
+#if !NET8_0
     /// <inheritdoc />
     protected WhiteSpaceStringException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+#endif
 }

--- a/Code/Light.GuardClauses/Light.GuardClauses.csproj
+++ b/Code/Light.GuardClauses/Light.GuardClauses.csproj
@@ -3,11 +3,12 @@
     <Import Project="..\Version.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
         <Description>A lightweight .NET library for expressive Guard Clauses.</Description>
         <Authors>Kenny Pflug</Authors>
         <Company>Kenny Pflug</Company>
         <Nullable>enable</Nullable>
+        <IsAotCompatible Condition="'$(TargetFramework)' == 'net8.0'">true</IsAotCompatible>
         <Copyright>Copyright © Kenny Pflug 2016, 2023</Copyright>
         <LangVersion>11.0</LangVersion>
         <TreatWarningsAsErrors Condition="'$(Configuration)' == 'Release'">true</TreatWarningsAsErrors>

--- a/Code/Light.GuardClauses/Light.GuardClauses.csproj
+++ b/Code/Light.GuardClauses/Light.GuardClauses.csproj
@@ -10,7 +10,7 @@
         <Nullable>enable</Nullable>
         <IsAotCompatible Condition="'$(TargetFramework)' == 'net8.0'">true</IsAotCompatible>
         <Copyright>Copyright © Kenny Pflug 2016, 2023</Copyright>
-        <LangVersion>11.0</LangVersion>
+        <LangVersion>12</LangVersion>
         <TreatWarningsAsErrors Condition="'$(Configuration)' == 'Release'">true</TreatWarningsAsErrors>
         <IsPackable>true</IsPackable>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -26,16 +26,17 @@
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageReleaseNotes>
-Light.GuardClauses 10.2.0
+Light.GuardClauses 11.0.0-preview1
 --------------------------------
 
-- Added IsLessThanOrApproximately and IsGreaterThanOrApproximately assertions for doubles and floats
-- Added "IsTrimmedXXX" and "MustBeTrimmedXXX" assertions for strings
+- Light.GuardClauses now targets .NET 8 and is AOT-compatible
+- breaking: EnumInfo&lt;T&gt; no longer has the UnderlyingType property
+- In AOT scenarios, avoid the Type-related assertions, they are marked with the DynamicallyAccessedMembersAttribute
         </PackageReleaseNotes>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+        <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" Condition="'$(TargetFramework)' != 'net8.0'" />
         <PackageReference Include="System.Memory" Version="4.5.5" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
         <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="all" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />

--- a/Code/Light.GuardClauses/Light.GuardClauses.csproj
+++ b/Code/Light.GuardClauses/Light.GuardClauses.csproj
@@ -26,7 +26,7 @@
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageReleaseNotes>
-Light.GuardClauses 11.0.0-preview1
+Light.GuardClauses 11.0.0
 --------------------------------
 
 - Light.GuardClauses now targets .NET 8 and is AOT-compatible

--- a/Code/Version.props
+++ b/Code/Version.props
@@ -1,5 +1,5 @@
 ﻿<Project>
     <PropertyGroup>
-        <Version>10.2.0</Version>
+        <Version>11.0.0-preview1</Version>
     </PropertyGroup>
 </Project>

--- a/Code/Version.props
+++ b/Code/Version.props
@@ -1,5 +1,5 @@
 ﻿<Project>
     <PropertyGroup>
-        <Version>11.0.0-preview1</Version>
+        <Version>11.0.0</Version>
     </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 **A lightweight .NET library for expressive Guard Clauses.** 
 
 [![License](https://img.shields.io/badge/License-MIT-green.svg?style=for-the-badge)](https://github.com/feO2x/Light.GuardClauses/blob/master/LICENSE)
-[![NuGet](https://img.shields.io/badge/NuGet-11.0.0-preview1-blue.svg?style=for-the-badge)](https://www.nuget.org/packages/Light.GuardClauses/)
-[![Source Code](https://img.shields.io/badge/Source%20Code-11.0.0-preview1-blue.svg?style=for-the-badge)](https://github.com/feO2x/Light.GuardClauses/blob/master/Light.GuardClauses.SingleFile.cs)
+[![NuGet](https://img.shields.io/badge/NuGet-11.0.0-blue.svg?style=for-the-badge)](https://www.nuget.org/packages/Light.GuardClauses/)
+[![Source Code](https://img.shields.io/badge/Source%20Code-11.0.0-blue.svg?style=for-the-badge)](https://github.com/feO2x/Light.GuardClauses/blob/master/Light.GuardClauses.SingleFile.cs)
 [![Documentation](https://img.shields.io/badge/Docs-Wiki-yellowgreen.svg?style=for-the-badge)](https://github.com/feO2x/Light.GuardClauses/wiki)
 [![Documentation](https://img.shields.io/badge/Docs-Changelog-yellowgreen.svg?style=for-the-badge)](https://github.com/feO2x/Light.GuardClauses/releases)
 
@@ -92,11 +92,13 @@ Every assertion is well-documented - explore them using IntelliSense or check ou
 
 ## Light.GuardClauses is optimized
 
-Since version 4.x, **Light.GuardClauses** is optimized for performance (measured in .NET 4.8 and .NET 6). With the incredible help of [@redknightlois](https://github.com/redknightlois) and the awesome tool [Benchmark.NET](https://github.com/dotnet/BenchmarkDotNet), most assertions are as fast as your imperative code would be.
+Since version 4, **Light.GuardClauses** is optimized for performance (measured in .NET 4.8 and .NET 6). With the incredible help of [@redknightlois](https://github.com/redknightlois) and the awesome tool [BenchmarkDotNet](https://github.com/dotnet/BenchmarkDotNet), most assertions are as fast as your imperative code would be.
 
-**Light.GuardClauses** has support for [.NET analyzers / FxCopAnalyzers](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/overview) with the `ValidatedNotNullAttribute`. Analyzers will know when an assertion validated that a parameters is not null and consequently, CA1062 will not be raised. 
+**Light.GuardClauses** has support for [.NET analyzers / FxCopAnalyzers](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/overview) with the `ValidatedNotNullAttribute`. Analyzers will know when an assertion validated that a parameters is not null and consequently, CA1062 will not be raised.
 
 Furthermore, **Light.GuardClauses** has support for ReSharper since version 4.x. Via [Contract Annotations](https://www.jetbrains.com/help/resharper/Contract_Annotations.html), R# knows when assertions do not return a null value and thus removes squiggly lines indicating a possible `NullReferenceException`. Since version 10.1.0, Light.GuardClauses also annotates assertions that do not iterate over an `IEnumerable<T>` with ReSharper's `NoEnumerationAttribute` - ReSharper will then not indicate a "Possible multiple enumeration" (thanks to [cdonnellytx](https://github.com/cdonnellytx) for this contribution).
+
+Since version 11, Light.GuardClauses supports Native AOT.
 
 **Light.GuardClauses** supports C#8 Nullable Reference Types since version 8.0.
 
@@ -112,7 +114,7 @@ Light.GuardClauses is available as a [NuGet package](https://www.nuget.org/packa
 
 - **dotnet CLI**: `dotnet add package Light.GuardClauses`
 - **Visual Studio Package Manager Console**: `Install-Package Light.GuardClauses`
-- **Package Reference in csproj**: `<PackageReference Include="Light.GuardClauses" Version="11.0.0-preview1" />`
+- **Package Reference in csproj**: `<PackageReference Include="Light.GuardClauses" Version="11.0.0" />`
 
 Also, you can incorporate Light.GuardClauses as a **single source file** where the API is changed to `internal`. This is especially interesting for framework / library developers that do not want to have a dependency on the Light.GuardClauses DLL. You can grab the default .NET Standard 2.0 version in [Light.GuardClauses.SingleFile.cs](https://github.com/feO2x/Light.GuardClauses/blob/master/Light.GuardClauses.SingleFile.cs) or you can use the [Light.GuardClauses.SourceCodeTransformation](https://github.com/feO2x/Light.GuardClauses/tree/master/Code/Light.GuardClauses.SourceCodeTransformation) project to create your custom file. You can learn more about it [here](https://github.com/feO2x/Light.GuardClauses/wiki/Including-Light.GuardClauses-as-source-code).
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 **A lightweight .NET library for expressive Guard Clauses.** 
 
 [![License](https://img.shields.io/badge/License-MIT-green.svg?style=for-the-badge)](https://github.com/feO2x/Light.GuardClauses/blob/master/LICENSE)
-[![NuGet](https://img.shields.io/badge/NuGet-10.2.0-blue.svg?style=for-the-badge)](https://www.nuget.org/packages/Light.GuardClauses/)
-[![Source Code](https://img.shields.io/badge/Source%20Code-10.2.0-blue.svg?style=for-the-badge)](https://github.com/feO2x/Light.GuardClauses/blob/master/Light.GuardClauses.SingleFile.cs)
+[![NuGet](https://img.shields.io/badge/NuGet-11.0.0-preview1-blue.svg?style=for-the-badge)](https://www.nuget.org/packages/Light.GuardClauses/)
+[![Source Code](https://img.shields.io/badge/Source%20Code-11.0.0-preview1-blue.svg?style=for-the-badge)](https://github.com/feO2x/Light.GuardClauses/blob/master/Light.GuardClauses.SingleFile.cs)
 [![Documentation](https://img.shields.io/badge/Docs-Wiki-yellowgreen.svg?style=for-the-badge)](https://github.com/feO2x/Light.GuardClauses/wiki)
 [![Documentation](https://img.shields.io/badge/Docs-Changelog-yellowgreen.svg?style=for-the-badge)](https://github.com/feO2x/Light.GuardClauses/releases)
 
@@ -112,7 +112,7 @@ Light.GuardClauses is available as a [NuGet package](https://www.nuget.org/packa
 
 - **dotnet CLI**: `dotnet add package Light.GuardClauses`
 - **Visual Studio Package Manager Console**: `Install-Package Light.GuardClauses`
-- **Package Reference in csproj**: `<PackageReference Include="Light.GuardClauses" Version="10.2.0" />`
+- **Package Reference in csproj**: `<PackageReference Include="Light.GuardClauses" Version="11.0.0-preview1" />`
 
 Also, you can incorporate Light.GuardClauses as a **single source file** where the API is changed to `internal`. This is especially interesting for framework / library developers that do not want to have a dependency on the Light.GuardClauses DLL. You can grab the default .NET Standard 2.0 version in [Light.GuardClauses.SingleFile.cs](https://github.com/feO2x/Light.GuardClauses/blob/master/Light.GuardClauses.SingleFile.cs) or you can use the [Light.GuardClauses.SourceCodeTransformation](https://github.com/feO2x/Light.GuardClauses/tree/master/Code/Light.GuardClauses.SourceCodeTransformation) project to create your custom file. You can learn more about it [here](https://github.com/feO2x/Light.GuardClauses/wiki/Including-Light.GuardClauses-as-source-code).
 


### PR DESCRIPTION
Fixes https://github.com/feO2x/Light.GuardClauses/issues/88

Light.GuardClauses now explicitly targets .NET 8 and enables `IsAotCompatible` for it. I had to rework the `EnumInfo<T>` class and add the `DynamicallyAccessedMembersAttribute` to some parameters of the type assertions (but these shouldn't be used in AOT scenarios anyway).

We should only merge this PR once .NET 8 is released.