### PR TITLE
Collection range indices

### DIFF
--- a/Code/Light.GuardClauses.Performance/CollectionAssertions/CountBenchmark.cs
+++ b/Code/Light.GuardClauses.Performance/CollectionAssertions/CountBenchmark.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using Light.GuardClauses.FrameworkExtensions;
+
+namespace Light.GuardClauses.Performance.CollectionAssertions;
+
+public class ListCountBenchmark
+{
+    public List<int> List;
+    
+    // ReSharper disable once UnusedAutoPropertyAccessor.Global
+    [Params(100, 1000)]
+    public int NumberOfItems { get; set; }
+
+    [GlobalSetup]
+    public void Setup() => List = Enumerable.Range(1, NumberOfItems).ToList();
+
+    // ReSharper disable once UseCollectionCountProperty
+    [Benchmark(Baseline = true)]
+    public int LinqCount() => List.Count();
+
+    [Benchmark]
+    public int ExistingEnumerableCount() => EnumerableExtensions.Count(List);
+
+    [Benchmark]
+    public int NewEnumerableOfTGetCount() => List.GetCount();
+}
+
+public class StringCountBenchmark
+{
+    public string String;
+    
+    // ReSharper disable once UnusedAutoPropertyAccessor.Global
+    [Params(100, 1000)]
+    public int NumberOfItems { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var random = new Random(42);
+        var array = new char[NumberOfItems];
+        for (var i = 0; i < array.Length; i++)
+        {
+            array[i] = (char) random.Next('a', 'z' + 1);
+        }
+
+        String = new (array);
+    }
+
+    // ReSharper disable once UseCollectionCountProperty
+    [Benchmark(Baseline = true)]
+    public int LinqCount() => String.Count();
+
+    [Benchmark]
+    public int ExistingEnumerableCount() => EnumerableExtensions.Count(String);
+
+    [Benchmark]
+    public int NewEnumerableOfTGetCount() => String.GetCount();
+}
+
+public class MyImmutableArrayCountBenchmark
+{
+    public MyImmutableArray<int> MyArray;
+    
+    // ReSharper disable once UnusedAutoPropertyAccessor.Global
+    [Params(100, 1000)]
+    public int NumberOfItems { get; set; }
+    
+    [GlobalSetup]
+    public void Setup() => MyArray = new (Enumerable.Range(1, NumberOfItems).ToArray());
+    
+    // ReSharper disable once UseCollectionCountProperty
+    [Benchmark(Baseline = true)]
+    public int LinqCount() => MyArray.Count();
+
+    [Benchmark]
+    public int ExistingEnumerableCount() => EnumerableExtensions.Count(MyArray);
+
+    [Benchmark]
+    public int NewEnumerableOfTGetCount() => MyArray.GetCount();
+}
+
+public sealed class MyImmutableArray<T> : IReadOnlyList<T>
+{
+    private readonly T[] _array;
+    
+    public MyImmutableArray(T[] array) => _array = array;
+
+    public IEnumerator<T> GetEnumerator() => ((IEnumerable<T>) _array).GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => _array.GetEnumerator();
+
+    public int Count => _array.Length;
+
+    public T this[int index] => _array[index];
+}

--- a/Code/Light.GuardClauses.Performance/Light.GuardClauses.Performance.csproj
+++ b/Code/Light.GuardClauses.Performance/Light.GuardClauses.Performance.csproj
@@ -3,11 +3,12 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net7.0;net48</TargetFrameworks>
+        <LangVersion>11</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\Light.GuardClauses\Light.GuardClauses.csproj" />
-        <PackageReference Include="BenchmarkDotNet" Version="0.13.7" />
+        <PackageReference Include="BenchmarkDotNet" Version="0.13.9" />
     </ItemGroup>
 
 </Project>

--- a/Code/Light.GuardClauses.Performance/Program.cs
+++ b/Code/Light.GuardClauses.Performance/Program.cs
@@ -11,7 +11,7 @@ namespace Light.GuardClauses.Performance
         private static IConfig DefaultConfiguration =>
             DefaultConfig
                .Instance
-               .AddJob(Job.Default.WithRuntime(CoreRuntime.Core60))
+               .AddJob(Job.Default.WithRuntime(CoreRuntime.Core70))
                .AddJob(Job.Default.WithRuntime(ClrRuntime.Net48))
                .AddDiagnoser(MemoryDiagnoser.Default, new DisassemblyDiagnoser(new DisassemblyDiagnoserConfig()));
 

--- a/Code/Light.GuardClauses.Tests/CollectionAssertions/MustBeOneOfTests.cs
+++ b/Code/Light.GuardClauses.Tests/CollectionAssertions/MustBeOneOfTests.cs
@@ -69,6 +69,6 @@ public static class MustBeOneOfTests
         Action act = () => myNumber.MustBeOneOf(Enumerable.Range(1, 10));
 
         act.Should().Throw<ValueIsNotOneOfException>()
-           .And.ParamName.Should().Be(nameof(myNumber));
+           .WithParameterName(nameof(myNumber));
     }
 }

--- a/Code/Light.GuardClauses.Tests/CollectionAssertions/MustContainTests.cs
+++ b/Code/Light.GuardClauses.Tests/CollectionAssertions/MustContainTests.cs
@@ -67,6 +67,6 @@ public static class MustContainTests
         var act = () => array.MustContain("Baz");
 
         act.Should().Throw<MissingItemException>()
-           .And.ParamName.Should().Be(nameof(array));
+           .WithParameterName(nameof(array));
     }
 }

--- a/Code/Light.GuardClauses.Tests/CollectionAssertions/MustHaveCountTests.cs
+++ b/Code/Light.GuardClauses.Tests/CollectionAssertions/MustHaveCountTests.cs
@@ -68,6 +68,6 @@ public static class MustHaveCountTests
         Action act = () => collection.MustHaveCount(5);
 
         act.Should().Throw<InvalidCollectionCountException>()
-           .And.ParamName.Should().Be(nameof(collection));
+           .WithParameterName(nameof(collection));
     }
 }

--- a/Code/Light.GuardClauses.Tests/CollectionAssertions/MustHaveMaximumCountTests.cs
+++ b/Code/Light.GuardClauses.Tests/CollectionAssertions/MustHaveMaximumCountTests.cs
@@ -69,6 +69,6 @@ public static class MustHaveMaximumCountTests
         var act = () => myCollection.MustHaveMaximumCount(2);
 
         act.Should().Throw<InvalidCollectionCountException>()
-           .And.ParamName.Should().Be(nameof(myCollection));
+           .WithParameterName(nameof(myCollection));
     }
 }

--- a/Code/Light.GuardClauses.Tests/CollectionAssertions/MustHaveMinimumCountTests.cs
+++ b/Code/Light.GuardClauses.Tests/CollectionAssertions/MustHaveMinimumCountTests.cs
@@ -70,6 +70,6 @@ public static class MustHaveMinimumCountTests
         Action act = () => myCollection.MustHaveMinimumCount(5);
 
         act.Should().Throw<InvalidCollectionCountException>()
-           .And.ParamName.Should().Be(nameof(myCollection));
+           .WithParameterName(nameof(myCollection));
     }
 }

--- a/Code/Light.GuardClauses.Tests/CollectionAssertions/MustNotBeNullOrEmptyTests.cs
+++ b/Code/Light.GuardClauses.Tests/CollectionAssertions/MustNotBeNullOrEmptyTests.cs
@@ -15,7 +15,7 @@ public static class MustNotBeNullOrEmptyTests
         Action act = () => ((object[]) null).MustNotBeNullOrEmpty("Foo");
 
         act.Should().Throw<ArgumentNullException>()
-           .And.ParamName.Should().Be("Foo");
+           .WithParameterName("Foo");
     }
 
     [Fact]
@@ -68,7 +68,7 @@ public static class MustNotBeNullOrEmptyTests
         Action act = () => emptyArray.MustNotBeNullOrEmpty();
 
         act.Should().Throw<EmptyCollectionException>()
-           .And.ParamName.Should().Be(nameof(emptyArray));
+           .WithParameterName(nameof(emptyArray));
     }
 
     [Fact]
@@ -80,6 +80,6 @@ public static class MustNotBeNullOrEmptyTests
         Action act = () => nullArray.MustNotBeNullOrEmpty();
 
         act.Should().Throw<ArgumentNullException>()
-           .And.ParamName.Should().Be(nameof(nullArray));
+           .WithParameterName(nameof(nullArray));
     }
 }

--- a/Code/Light.GuardClauses.Tests/CollectionAssertions/MustNotBeOneOfTests.cs
+++ b/Code/Light.GuardClauses.Tests/CollectionAssertions/MustNotBeOneOfTests.cs
@@ -67,6 +67,6 @@ public static class MustNotBeOneOfTests
         Action act = () => fortyTwo.MustNotBeOneOf(new[] { 42 });
 
         act.Should().Throw<ValueIsOneOfException>()
-           .And.ParamName.Should().Be(nameof(fortyTwo));
+           .WithParameterName(nameof(fortyTwo));
     }
 }

--- a/Code/Light.GuardClauses.Tests/CollectionAssertions/MustNotContainTests.cs
+++ b/Code/Light.GuardClauses.Tests/CollectionAssertions/MustNotContainTests.cs
@@ -73,6 +73,6 @@ public static class MustNotContainTests
         Action act = () => array.MustNotContain(3);
 
         act.Should().Throw<ExistingItemException>()
-           .And.ParamName.Should().Be(nameof(array));
+           .WithParameterName(nameof(array));
     }
 }

--- a/Code/Light.GuardClauses.Tests/CollectionAssertions/ReadOnlySpanMustBeLongerThanTests.cs
+++ b/Code/Light.GuardClauses.Tests/CollectionAssertions/ReadOnlySpanMustBeLongerThanTests.cs
@@ -85,6 +85,6 @@ public static class ReadOnlySpanMustBeLongerThanTests
         };
 
         act.Should().Throw<InvalidCollectionCountException>()
-           .And.ParamName.Should().Be("mySpan");
+           .WithParameterName("mySpan");
     }
 }

--- a/Code/Light.GuardClauses.Tests/CollectionAssertions/ReadOnlySpanMustBeShorterThanOrEqualToTests.cs
+++ b/Code/Light.GuardClauses.Tests/CollectionAssertions/ReadOnlySpanMustBeShorterThanOrEqualToTests.cs
@@ -86,6 +86,6 @@ public static class ReadOnlySpanMustBeShorterThanOrEqualToTests
         };
 
         act.Should().Throw<InvalidCollectionCountException>()
-           .And.ParamName.Should().Be("span");
+           .WithParameterName("span");
     }
 }

--- a/Code/Light.GuardClauses.Tests/CollectionAssertions/ReadOnlySpanMustBeShorterThanTests.cs
+++ b/Code/Light.GuardClauses.Tests/CollectionAssertions/ReadOnlySpanMustBeShorterThanTests.cs
@@ -84,6 +84,6 @@ public static class ReadOnlySpanMustBeShorterThanTests
         };
 
         act.Should().Throw<InvalidCollectionCountException>()
-           .And.ParamName.Should().Be("ultraSpan");
+           .WithParameterName("ultraSpan");
     }
 }

--- a/Code/Light.GuardClauses.Tests/CollectionAssertions/ReadOnlySpanMustHaveLengthTests.cs
+++ b/Code/Light.GuardClauses.Tests/CollectionAssertions/ReadOnlySpanMustHaveLengthTests.cs
@@ -87,6 +87,6 @@ public static class ReadOnlySpanMustHaveLengthTests
         };
 
         act.Should().Throw<InvalidCollectionCountException>()
-           .And.ParamName.Should().Be("mySpan");
+           .WithParameterName("mySpan");
     }
 }

--- a/Code/Light.GuardClauses.Tests/CollectionAssertions/ReadOnlySpanMustNotBeLongerThanOrEqualToTests.cs
+++ b/Code/Light.GuardClauses.Tests/CollectionAssertions/ReadOnlySpanMustNotBeLongerThanOrEqualToTests.cs
@@ -89,6 +89,6 @@ public static class ReadOnlySpanMustNotBeLongerThanOrEqualToTests
         };
 
         act.Should().Throw<InvalidCollectionCountException>()
-           .And.ParamName.Should().Be("mySpan");
+           .WithParameterName("mySpan");
     }
 }

--- a/Code/Light.GuardClauses.Tests/CollectionAssertions/SpanMustBeLongerThanOrEqualToTests.cs
+++ b/Code/Light.GuardClauses.Tests/CollectionAssertions/SpanMustBeLongerThanOrEqualToTests.cs
@@ -89,6 +89,6 @@ public static class SpanMustBeLongerThanOrEqualToTests
         };
 
         act.Should().Throw<InvalidCollectionCountException>()
-           .And.ParamName.Should().Be("mySpan");
+           .WithParameterName("mySpan");
     }
 }

--- a/Code/Light.GuardClauses.Tests/CollectionAssertions/SpanMustBeLongerThanTests.cs
+++ b/Code/Light.GuardClauses.Tests/CollectionAssertions/SpanMustBeLongerThanTests.cs
@@ -85,6 +85,6 @@ public static class SpanMustBeLongerThanTests
         };
 
         act.Should().Throw<InvalidCollectionCountException>()
-           .And.ParamName.Should().Be("mySpan");
+           .WithParameterName("mySpan");
     }
 }

--- a/Code/Light.GuardClauses.Tests/CollectionAssertions/SpanMustBeShorterThanOrEqualToTests.cs
+++ b/Code/Light.GuardClauses.Tests/CollectionAssertions/SpanMustBeShorterThanOrEqualToTests.cs
@@ -86,6 +86,6 @@ public static class SpanMustBeShorterThanOrEqualToTests
         };
 
         act.Should().Throw<InvalidCollectionCountException>()
-           .And.ParamName.Should().Be("span");
+           .WithParameterName("span");
     }
 }

--- a/Code/Light.GuardClauses.Tests/CollectionAssertions/SpanMustBeShorterThanTests.cs
+++ b/Code/Light.GuardClauses.Tests/CollectionAssertions/SpanMustBeShorterThanTests.cs
@@ -84,6 +84,6 @@ public static class SpanMustBeShorterThanTests
         };
 
         act.Should().Throw<InvalidCollectionCountException>()
-           .And.ParamName.Should().Be("span");
+           .WithParameterName("span");
     }
 }

--- a/Code/Light.GuardClauses.Tests/CollectionAssertions/SpanMustHaveLengthTests.cs
+++ b/Code/Light.GuardClauses.Tests/CollectionAssertions/SpanMustHaveLengthTests.cs
@@ -87,6 +87,6 @@ public static class SpanMustHaveLengthTests
         };
 
         act.Should().Throw<InvalidCollectionCountException>()
-           .And.ParamName.Should().Be("mySpan");
+           .WithParameterName("mySpan");
     }
 }

--- a/Code/Light.GuardClauses.Tests/CommonAssertions/InvalidStateTests.cs
+++ b/Code/Light.GuardClauses.Tests/CommonAssertions/InvalidStateTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using FluentAssertions;
+﻿using FluentAssertions;
 using Light.GuardClauses.Exceptions;
 using Xunit;
 

--- a/Code/Light.GuardClauses.Tests/CommonAssertions/IsValidEnumValueTests.cs
+++ b/Code/Light.GuardClauses.Tests/CommonAssertions/IsValidEnumValueTests.cs
@@ -40,8 +40,8 @@ public static class IsValidEnumValueTests
     [InlineData(-2)]
     [InlineData(-512)]
     [InlineData(int.MinValue)]
-    [InlineData(1024)]
     [InlineData(2048)]
+    [InlineData(2055)]
     [InlineData(int.MaxValue)]
     public static void InvalidNumberStyles(int invalidValue) => ((NumberStyles) invalidValue).IsValidEnumValue().Should().BeFalse();
 

--- a/Code/Light.GuardClauses.Tests/CommonAssertions/MustBeOfTypeTests.cs
+++ b/Code/Light.GuardClauses.Tests/CommonAssertions/MustBeOfTypeTests.cs
@@ -35,7 +35,7 @@ public static class MustBeOfTypeTests
         Action act = () => ((object) null).MustBeOfType<string>("Foo");
 
         act.Should().Throw<ArgumentNullException>()
-           .And.ParamName.Should().Be("Foo");
+           .WithParameterName("Foo");
     }
 
     [Fact]
@@ -72,7 +72,7 @@ public static class MustBeOfTypeTests
         Action act = () => someValue.MustBeOfType<Exception>();
 
         act.Should().Throw<TypeCastException>()
-           .And.ParamName.Should().Be(nameof(someValue));
+           .WithParameterName(nameof(someValue));
     }
 
     [Fact]
@@ -84,6 +84,6 @@ public static class MustBeOfTypeTests
         Action act = () => myValue.MustBeOfType<string>();
 
         act.Should().Throw<ArgumentNullException>()
-           .And.ParamName.Should().Be(nameof(myValue));
+           .WithParameterName(nameof(myValue));
     }
 }

--- a/Code/Light.GuardClauses.Tests/CommonAssertions/MustBeTests.cs
+++ b/Code/Light.GuardClauses.Tests/CommonAssertions/MustBeTests.cs
@@ -85,7 +85,7 @@ public static class MustBeTests
         Action act = () => five.MustBe(4);
 
         act.Should().Throw<ValuesNotEqualException>()
-           .And.ParamName.Should().Be(nameof(five));
+           .WithParameterName(nameof(five));
     }
 
     [Fact]
@@ -96,6 +96,6 @@ public static class MustBeTests
         Action act = () => seven.MustBe(1, new EqualityComparerStub<int>(false));
 
         act.Should().Throw<ValuesNotEqualException>()
-           .And.ParamName.Should().Be(nameof(seven));
+           .WithParameterName(nameof(seven));
     }
 }

--- a/Code/Light.GuardClauses.Tests/CommonAssertions/MustBeValidEnumValueTests.cs
+++ b/Code/Light.GuardClauses.Tests/CommonAssertions/MustBeValidEnumValueTests.cs
@@ -60,7 +60,7 @@ public static class MustBeValidEnumValueTests
         Action act = () => someValue.MustBeValidEnumValue();
 
         act.Should().Throw<EnumValueNotDefinedException>()
-           .And.ParamName.Should().Be(nameof(someValue));
+           .WithParameterName(nameof(someValue));
     }
 }
 

--- a/Code/Light.GuardClauses.Tests/CommonAssertions/MustHaveValueTests.cs
+++ b/Code/Light.GuardClauses.Tests/CommonAssertions/MustHaveValueTests.cs
@@ -42,6 +42,6 @@ public static class MustHaveValueTests
         Action act = () => nullable.MustHaveValue();
 
         act.Should().Throw<NullableHasNoValueException>()
-           .And.ParamName.Should().Be(nameof(nullable));
+           .WithParameterName(nameof(nullable));
     }
 }

--- a/Code/Light.GuardClauses.Tests/CommonAssertions/MustNotBeDefaultTests.cs
+++ b/Code/Light.GuardClauses.Tests/CommonAssertions/MustNotBeDefaultTests.cs
@@ -94,7 +94,7 @@ public static class MustNotBeDefaultTests
         Action act = () => someParameter.MustNotBeDefault();
 
         act.Should().Throw<ArgumentDefaultException>()
-           .And.ParamName.Should().Be(nameof(someParameter));
+           .WithParameterName(nameof(someParameter));
     }
 
 }

--- a/Code/Light.GuardClauses.Tests/CommonAssertions/MustNotBeEmptyGuidTests.cs
+++ b/Code/Light.GuardClauses.Tests/CommonAssertions/MustNotBeEmptyGuidTests.cs
@@ -15,7 +15,7 @@ public static class MustNotBeEmptyGuidTests
         Action act = () => emptyGuid.MustNotBeEmpty(nameof(emptyGuid));
 
         act.Should().Throw<EmptyGuidException>()
-           .And.ParamName.Should().Be(nameof(emptyGuid));
+           .WithParameterName(nameof(emptyGuid));
     }
 
     [Fact]
@@ -44,6 +44,6 @@ public static class MustNotBeEmptyGuidTests
         Action act = () => emptyGuid.MustNotBeEmpty();
 
         act.Should().Throw<EmptyGuidException>()
-           .And.ParamName.Should().Be(nameof(emptyGuid));
+           .WithParameterName(nameof(emptyGuid));
     }
 }

--- a/Code/Light.GuardClauses.Tests/CommonAssertions/MustNotBeNullReferenceTests.cs
+++ b/Code/Light.GuardClauses.Tests/CommonAssertions/MustNotBeNullReferenceTests.cs
@@ -63,6 +63,6 @@ public static class MustNotBeNullReferenceTests
         Action act = () => someParameter.MustNotBeNullReference();
 
         act.Should().Throw<ArgumentNullException>()
-           .And.ParamName.Should().Be(nameof(someParameter));
+           .WithParameterName(nameof(someParameter));
     }
 }

--- a/Code/Light.GuardClauses.Tests/CommonAssertions/MustNotBeNullTests.cs
+++ b/Code/Light.GuardClauses.Tests/CommonAssertions/MustNotBeNullTests.cs
@@ -41,6 +41,6 @@ public static class MustNotBeNullTests
         Action act = () => someParameter.MustNotBeNull();
 
         act.Should().Throw<ArgumentNullException>()
-           .And.ParamName.Should().Be(nameof(someParameter));
+           .WithParameterName(nameof(someParameter));
     }
 }

--- a/Code/Light.GuardClauses.Tests/CommonAssertions/MustNotBeSameAsTests.cs
+++ b/Code/Light.GuardClauses.Tests/CommonAssertions/MustNotBeSameAsTests.cs
@@ -45,6 +45,6 @@ public static class MustNotBeSameAsTests
         Action act = () => object1.MustNotBeSameAs(object1);
 
         act.Should().Throw<SameObjectReferenceException>()
-           .And.ParamName.Should().Be(nameof(object1));
+           .WithParameterName(nameof(object1));
     }
 }

--- a/Code/Light.GuardClauses.Tests/CommonAssertions/MustNotBeTests.cs
+++ b/Code/Light.GuardClauses.Tests/CommonAssertions/MustNotBeTests.cs
@@ -82,7 +82,7 @@ public static class MustNotBeTests
         Action act = () => eight.MustNotBe(8);
 
         act.Should().Throw<ValuesEqualException>()
-           .And.ParamName.Should().Be(nameof(eight));
+           .WithParameterName(nameof(eight));
     }
 
     [Fact]
@@ -93,6 +93,6 @@ public static class MustNotBeTests
         Action act = () => foo.MustNotBe("Foo", new EqualityComparerStub<string>(true));
 
         act.Should().Throw<ValuesEqualException>()
-           .And.ParamName.Should().Be(nameof(foo));
+           .WithParameterName(nameof(foo));
     }
 }

--- a/Code/Light.GuardClauses.Tests/ComparableAssertions/MustBeGreaterThanOrEqualToTests.cs
+++ b/Code/Light.GuardClauses.Tests/ComparableAssertions/MustBeGreaterThanOrEqualToTests.cs
@@ -53,6 +53,6 @@ public static class MustBeGreaterThanOrEqualToTests
         Action act = () => threePointThree.MustBeGreaterThanOrEqualTo(5.0);
 
         act.Should().Throw<ArgumentOutOfRangeException>()
-           .And.ParamName.Should().Be(nameof(threePointThree));
+           .WithParameterName(nameof(threePointThree));
     }
 }

--- a/Code/Light.GuardClauses.Tests/ComparableAssertions/MustBeGreaterThanTests.cs
+++ b/Code/Light.GuardClauses.Tests/ComparableAssertions/MustBeGreaterThanTests.cs
@@ -55,6 +55,6 @@ public static class MustBeGreaterThanTests
         Action act = () => fifteen.MustBeGreaterThan(20);
 
         act.Should().Throw<ArgumentOutOfRangeException>()
-           .And.ParamName.Should().Be(nameof(fifteen));
+           .WithParameterName(nameof(fifteen));
     }
 }

--- a/Code/Light.GuardClauses.Tests/ComparableAssertions/MustBeInTests.cs
+++ b/Code/Light.GuardClauses.Tests/ComparableAssertions/MustBeInTests.cs
@@ -79,6 +79,6 @@ public static class MustBeInTests
         Action act = () => twenty.MustBeIn(Range.FromInclusive(10).ToInclusive(15));
 
         act.Should().Throw<ArgumentOutOfRangeException>()
-           .And.ParamName.Should().Be(nameof(twenty));
+           .WithParameterName(nameof(twenty));
     }
 }

--- a/Code/Light.GuardClauses.Tests/ComparableAssertions/MustBeLessThanOrEqualToTests.cs
+++ b/Code/Light.GuardClauses.Tests/ComparableAssertions/MustBeLessThanOrEqualToTests.cs
@@ -52,6 +52,6 @@ public static class MustBeLessThanOrEqualToTests
         Action act = () => six.MustBeLessThanOrEqualTo(5);
 
         act.Should().Throw<ArgumentOutOfRangeException>()
-           .And.ParamName.Should().Be(nameof(six));
+           .WithParameterName(nameof(six));
     }
 }

--- a/Code/Light.GuardClauses.Tests/ComparableAssertions/MustBeLessThanTests.cs
+++ b/Code/Light.GuardClauses.Tests/ComparableAssertions/MustBeLessThanTests.cs
@@ -56,6 +56,6 @@ public static class MustBeLessThanTests
         Action act = () => ten.MustBeLessThan(7);
 
         act.Should().Throw<ArgumentOutOfRangeException>()
-           .And.ParamName.Should().Be(nameof(ten));
+           .WithParameterName(nameof(ten));
     }
 }

--- a/Code/Light.GuardClauses.Tests/ComparableAssertions/MustNotBeGreaterThanOrEqualToTests.cs
+++ b/Code/Light.GuardClauses.Tests/ComparableAssertions/MustNotBeGreaterThanOrEqualToTests.cs
@@ -53,6 +53,6 @@ public static class MustNotBeGreaterThanOrEqualToTests
         Action act = () => four.MustNotBeGreaterThanOrEqualTo(4);
 
         act.Should().Throw<ArgumentOutOfRangeException>()
-           .And.ParamName.Should().Be(nameof(four));
+           .WithParameterName(nameof(four));
     }
 }

--- a/Code/Light.GuardClauses.Tests/ComparableAssertions/MustNotBeGreaterThanTests.cs
+++ b/Code/Light.GuardClauses.Tests/ComparableAssertions/MustNotBeGreaterThanTests.cs
@@ -54,6 +54,6 @@ public static class MustNotBeGreaterThanTests
         Action act = () => five.MustNotBeGreaterThan(2);
 
         act.Should().Throw<ArgumentOutOfRangeException>()
-           .And.ParamName.Should().Be(nameof(five));
+           .WithParameterName(nameof(five));
     }
 }

--- a/Code/Light.GuardClauses.Tests/ComparableAssertions/MustNotBeInTests.cs
+++ b/Code/Light.GuardClauses.Tests/ComparableAssertions/MustNotBeInTests.cs
@@ -82,6 +82,6 @@ public static class MustNotBeInTests
         Action act = () => two.MustNotBeIn(Range.FromInclusive(1).ToInclusive(5));
 
         act.Should().Throw<ArgumentOutOfRangeException>()
-           .And.ParamName.Should().Be(nameof(two));
+           .WithParameterName(nameof(two));
     }
 }

--- a/Code/Light.GuardClauses.Tests/ComparableAssertions/MustNotBeLessThanOrEqualToTests.cs
+++ b/Code/Light.GuardClauses.Tests/ComparableAssertions/MustNotBeLessThanOrEqualToTests.cs
@@ -59,6 +59,6 @@ public static class MustNotBeLessThanOrEqualToTests
         Action act = () => nine.MustNotBeLessThanOrEqualTo(12);
 
         act.Should().Throw<ArgumentOutOfRangeException>()
-           .And.ParamName.Should().Be(nameof(nine));
+           .WithParameterName(nameof(nine));
     }
 }

--- a/Code/Light.GuardClauses.Tests/ComparableAssertions/MustNotBeLessThanTests.cs
+++ b/Code/Light.GuardClauses.Tests/ComparableAssertions/MustNotBeLessThanTests.cs
@@ -65,6 +65,6 @@ public static class MustNotBeLessThanTests
         Action act = () => seventeen.MustNotBeLessThan(20);
 
         act.Should().Throw<ArgumentOutOfRangeException>()
-           .And.ParamName.Should().Be(nameof(seventeen));
+           .WithParameterName(nameof(seventeen));
     }
 }

--- a/Code/Light.GuardClauses.Tests/ComparableAssertions/RangeTests.cs
+++ b/Code/Light.GuardClauses.Tests/ComparableAssertions/RangeTests.cs
@@ -83,8 +83,7 @@ public static class RangeTests
         // ReSharper disable once RedundantCast -- I want to specifically target the overload accepting IEnumerable
         var act = () => Range.For(((IEnumerable) null)!);
 
-        act.Should().Throw<ArgumentNullException>()
-           .And.ParamName.Should().Be("enumerable");
+        act.Should().Throw<ArgumentNullException>().WithParameterName("enumerable");
     }
 
     [Theory]
@@ -113,8 +112,7 @@ public static class RangeTests
     {
         var act = () => Range.For(((IEnumerable<string>) null)!);
 
-        act.Should().Throw<ArgumentNullException>()
-           .And.ParamName.Should().Be("enumerable");
+        act.Should().Throw<ArgumentNullException>().WithParameterName("enumerable");
     }
 
     [Theory]

--- a/Code/Light.GuardClauses.Tests/ComparableAssertions/RangeTests.cs
+++ b/Code/Light.GuardClauses.Tests/ComparableAssertions/RangeTests.cs
@@ -1,5 +1,10 @@
 ﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
 using FluentAssertions;
+using Light.GuardClauses.FrameworkExtensions;
 using Xunit;
 
 namespace Light.GuardClauses.Tests.ComparableAssertions;
@@ -49,4 +54,76 @@ public static class RangeTests
         act.Should().Throw<ArgumentOutOfRangeException>().And
            .Message.Should().Contain($"{nameof(to)} must not be less than {from}, but it actually is {to}.");
     }
+
+    [Theory]
+    [MemberData(nameof(Collections))]
+    public static void RangeForCollections(IEnumerable enumerable)
+    {
+        // ReSharper disable PossibleMultipleEnumeration
+        var range = Range.For(enumerable);
+
+        var expectedRange = new Range<int>(0, enumerable.Count(), true, false);
+        range.Should().Be(expectedRange);
+        // ReSharper restore PossibleMultipleEnumeration
+    }
+
+    public static readonly TheoryData<IEnumerable> Collections =
+        new ()
+        {
+            new List<int> { 1, 2 ,3 ,4},
+            "This is a long string",
+            new[] { 'a', 'b', 'c', 'd' },
+            new ObservableCollection<long> { 1, -1 },
+            new ArrayList()
+        };
+
+    [Theory]
+    [MemberData(nameof(Memories))]
+    public static void RangeForMemory(Memory<int> memory)
+    {
+        var range = Range.For(memory);
+
+        var expectedRange = new Range<int>(0, memory.Length, true, false);
+        range.Should().Be(expectedRange);
+    }
+
+    [Theory]
+    [MemberData(nameof(Memories))]
+    public static void RangeForReadOnlyMemory(Memory<int> memory)
+    {
+        ReadOnlyMemory<int> readOnlyMemory = memory;
+        var range = Range.For(readOnlyMemory);
+        
+        var expectedRange = new Range<int>(0, memory.Length, true, false);
+        range.Should().Be(expectedRange);
+    }
+
+    [Theory]
+    [MemberData(nameof(Memories))]
+    public static void RangeForSpan(Memory<int> memory)
+    {
+        var range = Range.For(memory.Span);
+        
+        var expectedRange = new Range<int>(0, memory.Length, true, false);
+        range.Should().Be(expectedRange);
+    }
+
+    [Theory]
+    [MemberData(nameof(Memories))]
+    public static void RangeForReadOnlySpan(Memory<int> memory)
+    {
+        ReadOnlySpan<int> readOnlySpan = memory.Span;
+        var range = Range.For(readOnlySpan);
+        
+        var expectedRange = new Range<int>(0, memory.Length, true, false);
+        range.Should().Be(expectedRange);
+    }
+
+    public static readonly TheoryData<Memory<int>> Memories =
+        new ()
+        {
+            new [] { 1, 2, 3, 4 },
+            Enumerable.Range(1, 500).ToArray(),
+            Array.Empty<int>()
+        };
 }

--- a/Code/Light.GuardClauses.Tests/ComparableAssertions/RangeTests.cs
+++ b/Code/Light.GuardClauses.Tests/ComparableAssertions/RangeTests.cs
@@ -70,12 +70,52 @@ public static class RangeTests
     public static readonly TheoryData<IEnumerable> Collections =
         new ()
         {
-            new List<int> { 1, 2 ,3 ,4},
+            new List<int> { 1, 2, 3, 4 },
             "This is a long string",
             new[] { 'a', 'b', 'c', 'd' },
             new ObservableCollection<long> { 1, -1 },
             new ArrayList()
         };
+
+    [Fact]
+    public static void EnumerableNull()
+    {
+        // ReSharper disable once RedundantCast -- I want to specifically target the overload accepting IEnumerable
+        var act = () => Range.For(((IEnumerable) null)!);
+
+        act.Should().Throw<ArgumentNullException>()
+           .And.ParamName.Should().Be("enumerable");
+    }
+
+    [Theory]
+    [MemberData(nameof(GenericCollections))]
+    public static void RangeForGenericCollections(IEnumerable<char> enumerable)
+    {
+        // ReSharper disable PossibleMultipleEnumeration
+        var range = Range.For(enumerable);
+
+        var expectedRange = new Range<int>(0, enumerable.Count(), true, false);
+        range.Should().Be(expectedRange);
+        // ReSharper restore PossibleMultipleEnumeration
+    }
+
+    public static readonly TheoryData<IEnumerable<char>> GenericCollections =
+        new ()
+        {
+            Array.Empty<char>(),
+            new List<char> { 'a', 'b', 'c' },
+            "007",
+            new ArraySegment<char>(new[] { 'a' })
+        };
+
+    [Fact]
+    public static void GenericEnumerableNull()
+    {
+        var act = () => Range.For(((IEnumerable<string>) null)!);
+
+        act.Should().Throw<ArgumentNullException>()
+           .And.ParamName.Should().Be("enumerable");
+    }
 
     [Theory]
     [MemberData(nameof(Memories))]
@@ -93,7 +133,7 @@ public static class RangeTests
     {
         ReadOnlyMemory<int> readOnlyMemory = memory;
         var range = Range.For(readOnlyMemory);
-        
+
         var expectedRange = new Range<int>(0, memory.Length, true, false);
         range.Should().Be(expectedRange);
     }
@@ -103,7 +143,7 @@ public static class RangeTests
     public static void RangeForSpan(Memory<int> memory)
     {
         var range = Range.For(memory.Span);
-        
+
         var expectedRange = new Range<int>(0, memory.Length, true, false);
         range.Should().Be(expectedRange);
     }
@@ -114,7 +154,7 @@ public static class RangeTests
     {
         ReadOnlySpan<int> readOnlySpan = memory.Span;
         var range = Range.For(readOnlySpan);
-        
+
         var expectedRange = new Range<int>(0, memory.Length, true, false);
         range.Should().Be(expectedRange);
     }
@@ -122,7 +162,7 @@ public static class RangeTests
     public static readonly TheoryData<Memory<int>> Memories =
         new ()
         {
-            new [] { 1, 2, 3, 4 },
+            new[] { 1, 2, 3, 4 },
             Enumerable.Range(1, 500).ToArray(),
             Array.Empty<int>()
         };

--- a/Code/Light.GuardClauses.Tests/DateTimeAssertions/MustBeLocalTests.cs
+++ b/Code/Light.GuardClauses.Tests/DateTimeAssertions/MustBeLocalTests.cs
@@ -53,6 +53,6 @@ public static class MustBeLocalTests
         Action act = () => invalidDateTime.MustBeLocal();
 
         act.Should().Throw<InvalidDateTimeException>()
-           .And.ParamName.Should().Be(nameof(invalidDateTime));
+           .WithParameterName(nameof(invalidDateTime));
     }
 }

--- a/Code/Light.GuardClauses.Tests/DateTimeAssertions/MustBeUnspecifiedTests.cs
+++ b/Code/Light.GuardClauses.Tests/DateTimeAssertions/MustBeUnspecifiedTests.cs
@@ -55,6 +55,6 @@ public static class MustBeUnspecifiedTests
         Action act = () => invalidDateTime.MustBeUnspecified();
 
         act.Should().Throw<InvalidDateTimeException>()
-           .And.ParamName.Should().Be(nameof(invalidDateTime));
+           .WithParameterName(nameof(invalidDateTime));
     }
 }

--- a/Code/Light.GuardClauses.Tests/DateTimeAssertions/MustBeUtcTests.cs
+++ b/Code/Light.GuardClauses.Tests/DateTimeAssertions/MustBeUtcTests.cs
@@ -55,6 +55,6 @@ public static class MustBeUtcTests
         Action act = () => invalidDateTime.MustBeUtc();
 
         act.Should().Throw<InvalidDateTimeException>()
-           .And.ParamName.Should().Be(nameof(invalidDateTime));
+           .WithParameterName(nameof(invalidDateTime));
     }
 }

--- a/Code/Light.GuardClauses.Tests/FrameworkExtensions/AsListTests.cs
+++ b/Code/Light.GuardClauses.Tests/FrameworkExtensions/AsListTests.cs
@@ -59,7 +59,7 @@ public static class AsListTests
         Action act = () => ((IEnumerable<string>) null)!.AsList();
 
         act.Should().Throw<ArgumentNullException>()
-           .And.ParamName.Should().Be("source");
+           .WithParameterName("source");
     }
 
     [Fact]

--- a/Code/Light.GuardClauses.Tests/FrameworkExtensions/AsListTests.cs
+++ b/Code/Light.GuardClauses.Tests/FrameworkExtensions/AsListTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Linq;
 using FluentAssertions;
 using Light.GuardClauses.FrameworkExtensions;
 using Xunit;
@@ -44,12 +43,12 @@ public static class AsListTests
     public static void ReturnsNewListIfCastNotPossible()
     {
         // ReSharper disable PossibleMultipleEnumeration
-        var enumerable = Enumerable.Range(1, 5);
+        var enumerable = LazyEnumerable();
 
         var list = enumerable.AsList();
 
         list.Should().NotBeSameAs(enumerable);
-        list.Should().BeOfType<List<int>>();
+        list.Should().BeOfType<List<string>>();
         list.Should().Equal(enumerable);
         // ReSharper restore PossibleMultipleEnumeration
     }

--- a/Code/Light.GuardClauses.Tests/FrameworkExtensions/AsReadOnlyListTests.cs
+++ b/Code/Light.GuardClauses.Tests/FrameworkExtensions/AsReadOnlyListTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Linq;
 using FluentAssertions;
 using Light.GuardClauses.FrameworkExtensions;
 using Xunit;
@@ -44,12 +43,12 @@ public static class AsReadOnlyListTests
     public static void ReturnsNewListIfCastNotPossible()
     {
         // ReSharper disable PossibleMultipleEnumeration
-        var enumerable = Enumerable.Range(1, 5);
+        var enumerable = LazyEnumerable();
 
         var list = enumerable.AsReadOnlyList();
 
         list.Should().NotBeSameAs(enumerable);
-        list.Should().BeOfType<List<int>>();
+        list.Should().BeOfType<List<string>>();
         list.Should().Equal(enumerable);
         // ReSharper restore PossibleMultipleEnumeration
     }

--- a/Code/Light.GuardClauses.Tests/FrameworkExtensions/AsReadOnlyListTests.cs
+++ b/Code/Light.GuardClauses.Tests/FrameworkExtensions/AsReadOnlyListTests.cs
@@ -59,7 +59,7 @@ public static class AsReadOnlyListTests
         Action act = () => ((IEnumerable<string>) null)!.AsReadOnlyList();
 
         act.Should().Throw<ArgumentNullException>()
-           .And.ParamName.Should().Be("source");
+           .WithParameterName("source");
     }
 
     [Fact]

--- a/Code/Light.GuardClauses.Tests/FrameworkExtensions/ExtractFieldTests.cs
+++ b/Code/Light.GuardClauses.Tests/FrameworkExtensions/ExtractFieldTests.cs
@@ -36,6 +36,6 @@ public static class ExtractFieldTests
         Action act = () => ((Expression<Func<object, object>>) null).ExtractField();
 
         act.Should().Throw<ArgumentNullException>()
-           .And.ParamName.Should().Be("expression");
+           .WithParameterName("expression");
     }
 }

--- a/Code/Light.GuardClauses.Tests/FrameworkExtensions/ExtractPropertyTests.cs
+++ b/Code/Light.GuardClauses.Tests/FrameworkExtensions/ExtractPropertyTests.cs
@@ -37,7 +37,7 @@ public static class ExtractPropertyTests
         Action act = () => ((Expression<Func<object, object>>) null).ExtractProperty();
 
         act.Should().Throw<ArgumentNullException>()
-           .And.ParamName.Should().Be("expression");
+           .WithParameterName("expression");
     }
 }
 

--- a/Code/Light.GuardClauses.Tests/StringAssertions/MustBeEmailAddressTests.cs
+++ b/Code/Light.GuardClauses.Tests/StringAssertions/MustBeEmailAddressTests.cs
@@ -112,6 +112,6 @@ public static class MustBeEmailAddressTests
         var act = () => email.MustBeEmailAddress();
 
         act.Should().Throw<InvalidEmailAddressException>()
-           .And.ParamName.Should().Be(nameof(email));
+           .WithParameterName(nameof(email));
     }
 }

--- a/Code/Light.GuardClauses.Tests/StringAssertions/MustBeLongerThanOrEqualToTests.cs
+++ b/Code/Light.GuardClauses.Tests/StringAssertions/MustBeLongerThanOrEqualToTests.cs
@@ -54,6 +54,6 @@ public static class MustBeLongerThanOrEqualToTests
         var act = () => foo.MustBeLongerThanOrEqualTo(4);
 
         act.Should().Throw<StringLengthException>()
-           .And.ParamName.Should().Be(nameof(foo));
+           .WithParameterName(nameof(foo));
     }
 }

--- a/Code/Light.GuardClauses.Tests/StringAssertions/MustBeLongerThanTests.cs
+++ b/Code/Light.GuardClauses.Tests/StringAssertions/MustBeLongerThanTests.cs
@@ -56,6 +56,6 @@ public static class MustBeLongerThanTests
         var act = () => @short.MustBeLongerThan(10);
 
         act.Should().Throw<StringLengthException>()
-           .And.ParamName.Should().Be("@short");
+           .WithParameterName("@short");
     }
 }

--- a/Code/Light.GuardClauses.Tests/StringAssertions/MustBeNewLineTests.cs
+++ b/Code/Light.GuardClauses.Tests/StringAssertions/MustBeNewLineTests.cs
@@ -24,7 +24,7 @@ public static class MustBeNewLineTests
         var act = () => stringValue.MustBeNewLine(nameof(stringValue));
 
         act.Should().Throw<ArgumentNullException>()
-           .And.ParamName.Should().Be(nameof(stringValue));
+           .WithParameterName(nameof(stringValue));
     }
 
     [Theory]
@@ -66,6 +66,6 @@ public static class MustBeNewLineTests
         var act = () => expression.MustBeNewLine();
 
         act.Should().Throw<StringException>()
-           .And.ParamName.Should().Be(nameof(expression));
+           .WithParameterName(nameof(expression));
     }
 }

--- a/Code/Light.GuardClauses.Tests/StringAssertions/MustBeShorterThanOrEqualToTests.cs
+++ b/Code/Light.GuardClauses.Tests/StringAssertions/MustBeShorterThanOrEqualToTests.cs
@@ -52,6 +52,6 @@ public static class MustBeShorterThanOrEqualToTests
         var act = () => message.MustBeShorterThanOrEqualTo(5);
 
         act.Should().Throw<StringLengthException>()
-           .And.ParamName.Should().Be(nameof(message));
+           .WithParameterName(nameof(message));
     }
 }

--- a/Code/Light.GuardClauses.Tests/StringAssertions/MustBeShorterThanTests.cs
+++ b/Code/Light.GuardClauses.Tests/StringAssertions/MustBeShorterThanTests.cs
@@ -52,6 +52,6 @@ public static class MustBeShorterThanTests
         var act = () => message.MustBeShorterThan(10);
 
         act.Should().Throw<StringLengthException>()
-           .And.ParamName.Should().Be(nameof(message));
+           .WithParameterName(nameof(message));
     }
 }

--- a/Code/Light.GuardClauses.Tests/StringAssertions/MustBeSubstringOfTests.cs
+++ b/Code/Light.GuardClauses.Tests/StringAssertions/MustBeSubstringOfTests.cs
@@ -141,6 +141,6 @@ public static class MustBeSubstringOfTests
         var act = () => foo.MustBeSubstringOf("Bar");
 
         act.Should().Throw<SubstringException>()
-           .And.ParamName.Should().Be(nameof(foo));
+           .WithParameterName(nameof(foo));
     }
 }

--- a/Code/Light.GuardClauses.Tests/StringAssertions/MustBeTests.cs
+++ b/Code/Light.GuardClauses.Tests/StringAssertions/MustBeTests.cs
@@ -74,6 +74,6 @@ public static class MustBeTests
         var act = () => myString.MustBe("Bar");
 
         act.Should().Throw<ValuesNotEqualException>()
-           .And.ParamName.Should().Be(nameof(myString));
+           .WithParameterName(nameof(myString));
     }
 }

--- a/Code/Light.GuardClauses.Tests/StringAssertions/MustBeTrimmedAtEndTests.cs
+++ b/Code/Light.GuardClauses.Tests/StringAssertions/MustBeTrimmedAtEndTests.cs
@@ -25,7 +25,7 @@ public static class MustBeTrimmedAtEndTests
         var act = () => nullString.MustBeTrimmedAtEnd(nameof(nullString));
 
         act.Should().Throw<ArgumentNullException>()
-           .And.ParamName.Should().Be(nameof(nullString));
+           .WithParameterName(nameof(nullString));
     }
 
     [Theory]
@@ -64,6 +64,6 @@ public static class MustBeTrimmedAtEndTests
         var act = () => invalidString.MustBeTrimmedAtEnd();
 
         act.Should().Throw<StringException>()
-           .And.ParamName.Should().Be(nameof(invalidString));
+           .WithParameterName(nameof(invalidString));
     }
 }

--- a/Code/Light.GuardClauses.Tests/StringAssertions/MustBeTrimmedAtStartTests.cs
+++ b/Code/Light.GuardClauses.Tests/StringAssertions/MustBeTrimmedAtStartTests.cs
@@ -25,7 +25,7 @@ public static class MustBeTrimmedAtStartTests
         var act = () => nullString.MustBeTrimmedAtStart(nameof(nullString));
 
         act.Should().Throw<ArgumentNullException>()
-           .And.ParamName.Should().Be(nameof(nullString));
+           .WithParameterName(nameof(nullString));
     }
 
     [Theory]
@@ -64,6 +64,6 @@ public static class MustBeTrimmedAtStartTests
         var act = () => invalidString.MustBeTrimmedAtStart();
 
         act.Should().Throw<StringException>()
-           .And.ParamName.Should().Be(nameof(invalidString));
+           .WithParameterName(nameof(invalidString));
     }
 }

--- a/Code/Light.GuardClauses.Tests/StringAssertions/MustBeTrimmedTests.cs
+++ b/Code/Light.GuardClauses.Tests/StringAssertions/MustBeTrimmedTests.cs
@@ -25,7 +25,7 @@ public static class MustBeTrimmedTests
         var act = () => nullString.MustBeTrimmed(nameof(nullString));
 
         act.Should().Throw<ArgumentNullException>()
-           .And.ParamName.Should().Be(nameof(nullString));
+           .WithParameterName(nameof(nullString));
     }
 
     [Theory]
@@ -68,6 +68,6 @@ public static class MustBeTrimmedTests
         var act = () => invalidString.MustBeTrimmed();
 
         act.Should().Throw<StringException>()
-           .And.ParamName.Should().Be(nameof(invalidString));
+           .WithParameterName(nameof(invalidString));
     }
 }

--- a/Code/Light.GuardClauses.Tests/StringAssertions/MustContainTests.cs
+++ b/Code/Light.GuardClauses.Tests/StringAssertions/MustContainTests.cs
@@ -118,6 +118,6 @@ public static class MustContainTests
         var act = () => foo.MustContain("Bar");
 
         act.Should().Throw<SubstringException>()
-           .And.ParamName.Should().Be(nameof(foo));
+           .WithParameterName(nameof(foo));
     }
 }

--- a/Code/Light.GuardClauses.Tests/StringAssertions/MustHaveLengthInTests.cs
+++ b/Code/Light.GuardClauses.Tests/StringAssertions/MustHaveLengthInTests.cs
@@ -66,6 +66,6 @@ public static class MustHaveLengthInTests
         var act = () => message.MustHaveLengthIn(Range.FromInclusive(3).ToExclusive(10));
 
         act.Should().Throw<StringLengthException>()
-           .And.ParamName.Should().Be(nameof(message));
+           .WithParameterName(nameof(message));
     }
 }

--- a/Code/Light.GuardClauses.Tests/StringAssertions/MustHaveLengthTests.cs
+++ b/Code/Light.GuardClauses.Tests/StringAssertions/MustHaveLengthTests.cs
@@ -54,6 +54,6 @@ public static class MustHaveLengthTests
         var act = () => foo.MustHaveLength(4);
 
         act.Should().Throw<StringLengthException>()
-           .And.ParamName.Should().Be(nameof(foo));
+           .WithParameterName(nameof(foo));
     }
 }

--- a/Code/Light.GuardClauses.Tests/StringAssertions/MustMatchTests.cs
+++ b/Code/Light.GuardClauses.Tests/StringAssertions/MustMatchTests.cs
@@ -82,6 +82,6 @@ public static class MustMatchTests
         var act = () => email.MustMatch(RegularExpressions.EmailRegex);
 
         act.Should().Throw<StringDoesNotMatchException>()
-           .And.ParamName.Should().Be(nameof(email));
+           .WithParameterName(nameof(email));
     }
 }

--- a/Code/Light.GuardClauses.Tests/StringAssertions/MustNotBeNullOrEmptyTests.cs
+++ b/Code/Light.GuardClauses.Tests/StringAssertions/MustNotBeNullOrEmptyTests.cs
@@ -13,7 +13,7 @@ public static class MustNotBeNullOrEmptyTests
         Action act = () => ((string) null).MustNotBeNullOrEmpty("Foo");
 
         act.Should().Throw<ArgumentNullException>()
-           .And.ParamName.Should().Be("Foo");
+           .WithParameterName("Foo");
     }
 
     [Fact]
@@ -58,6 +58,6 @@ public static class MustNotBeNullOrEmptyTests
         var act = () => nullString.MustNotBeNullOrEmpty();
 
         act.Should().Throw<ArgumentNullException>()
-           .And.ParamName.Should().Be(nameof(nullString));
+           .WithParameterName(nameof(nullString));
     }
 }

--- a/Code/Light.GuardClauses.Tests/StringAssertions/MustNotBeNullOrWhiteSpaceTests.cs
+++ b/Code/Light.GuardClauses.Tests/StringAssertions/MustNotBeNullOrWhiteSpaceTests.cs
@@ -13,7 +13,7 @@ public static class MustNotBeNullOrWhiteSpaceTests
         Action act = () => ((string) null).MustNotBeNullOrWhiteSpace("Foo");
 
         act.Should().Throw<ArgumentNullException>()
-           .And.ParamName.Should().Be("Foo");
+           .WithParameterName("Foo");
     }
 
     [Fact]
@@ -79,6 +79,6 @@ public static class MustNotBeNullOrWhiteSpaceTests
         var act = () => whiteSpaceString.MustNotBeNullOrWhiteSpace();
 
         act.Should().Throw<WhiteSpaceStringException>()
-           .And.ParamName.Should().Be(nameof(whiteSpaceString));
+           .WithParameterName(nameof(whiteSpaceString));
     }
 }

--- a/Code/Light.GuardClauses.Tests/StringAssertions/MustNotBeSubstringOfTests.cs
+++ b/Code/Light.GuardClauses.Tests/StringAssertions/MustNotBeSubstringOfTests.cs
@@ -132,6 +132,6 @@ public static class MustNotBeSubstringOfTests
         var act = () => message.MustNotBeSubstringOf("Foobar");
 
         act.Should().Throw<SubstringException>()
-           .And.ParamName.Should().Be(nameof(message));
+           .WithParameterName(nameof(message));
     }
 }

--- a/Code/Light.GuardClauses.Tests/StringAssertions/MustNotBeTests.cs
+++ b/Code/Light.GuardClauses.Tests/StringAssertions/MustNotBeTests.cs
@@ -74,6 +74,6 @@ public static class MustNotBeTests
         var act = () => message.MustNotBe("Foo");
 
         act.Should().Throw<ValuesEqualException>()
-           .And.ParamName.Should().Be(nameof(message));
+           .WithParameterName(nameof(message));
     }
 }

--- a/Code/Light.GuardClauses.Tests/StringAssertions/MustNotContainTests.cs
+++ b/Code/Light.GuardClauses.Tests/StringAssertions/MustNotContainTests.cs
@@ -111,6 +111,6 @@ public static class MustNotContainTests
         var act = () => bar.MustNotContain("ar");
 
         act.Should().Throw<SubstringException>()
-           .And.ParamName.Should().Be(nameof(bar));
+           .WithParameterName(nameof(bar));
     }
 }

--- a/Code/Light.GuardClauses.Tests/TypeAssertions/DerivesFromTests.cs
+++ b/Code/Light.GuardClauses.Tests/TypeAssertions/DerivesFromTests.cs
@@ -74,7 +74,7 @@ public static class DerivesFromTests
         Action act = () => type.DerivesFrom(typeof(object));
 
         act.Should().Throw<ArgumentNullException>()
-           .And.ParamName.Should().Be(nameof(type));
+           .WithParameterName(nameof(type));
     }
 
     [Fact]
@@ -86,7 +86,7 @@ public static class DerivesFromTests
         Action act = () => typeof(string).DerivesFrom(baseClass);
 
         act.Should().Throw<ArgumentNullException>()
-           .And.ParamName.Should().Be(nameof(baseClass));
+           .WithParameterName(nameof(baseClass));
     }
 
     public sealed class StringDictionary : Dictionary<string, object> { }

--- a/Code/Light.GuardClauses.Tests/TypeAssertions/ImplementsTests.cs
+++ b/Code/Light.GuardClauses.Tests/TypeAssertions/ImplementsTests.cs
@@ -42,7 +42,7 @@ public static class ImplementsTests
         Action act = () => type.Implements(typeof(IComparable));
 
         act.Should().Throw<ArgumentNullException>()
-           .And.ParamName.Should().Be(nameof(type));
+           .WithParameterName(nameof(type));
     }
 
     [Fact]
@@ -54,7 +54,7 @@ public static class ImplementsTests
         Action act = () => typeof(List<object>).Implements(interfaceType);
 
         act.Should().Throw<ArgumentNullException>()
-           .And.ParamName.Should().Be(nameof(interfaceType));
+           .WithParameterName(nameof(interfaceType));
     }
 
     private static void CheckImplements(Type type, Type interfaceType, bool expected) => 

--- a/Code/Light.GuardClauses.Tests/TypeAssertions/InheritsFromTests.cs
+++ b/Code/Light.GuardClauses.Tests/TypeAssertions/InheritsFromTests.cs
@@ -52,7 +52,7 @@ public static class InheritsFromTests
         Action act = () => type.InheritsFrom(typeof(object));
 
         act.Should().Throw<ArgumentNullException>()
-           .And.ParamName.Should().Be(nameof(type));
+           .WithParameterName(nameof(type));
     }
 
     [Fact(DisplayName = "IsDerivingFromOrImplementing must throw an ArgumentNullException when the specified base type is null.")]
@@ -64,7 +64,7 @@ public static class InheritsFromTests
         Action act = () => typeof(string).InheritsFrom(baseClassOrInterfaceType);
 
         act.Should().Throw<ArgumentNullException>()
-           .And.ParamName.Should().Be(nameof(baseClassOrInterfaceType));
+           .WithParameterName(nameof(baseClassOrInterfaceType));
     }
 
     private static void CheckInheritsFrom(Type type, Type baseClassOrInterfaceType, bool expected)

--- a/Code/Light.GuardClauses.Tests/TypeAssertions/IsOpenConstructedGenericTypeTests.cs
+++ b/Code/Light.GuardClauses.Tests/TypeAssertions/IsOpenConstructedGenericTypeTests.cs
@@ -32,6 +32,6 @@ public static class IsOpenConstructedGenericTypeTests
         Action act = () => ((Type) null).IsOpenConstructedGenericType();
 
         act.Should().Throw<ArgumentNullException>()
-           .And.ParamName.Should().Be("type");
+           .WithParameterName("type");
     }
 }

--- a/Code/Light.GuardClauses.Tests/TypeAssertions/IsOrDerivesFromTests.cs
+++ b/Code/Light.GuardClauses.Tests/TypeAssertions/IsOrDerivesFromTests.cs
@@ -31,7 +31,7 @@ public static class IsOrDerivesFromTests
         Action act = () => type.IsOrDerivesFrom(typeof(object));
 
         act.Should().Throw<ArgumentNullException>()
-           .And.ParamName.Should().Be(nameof(type));
+           .WithParameterName(nameof(type));
     }
 
     [Fact]
@@ -43,7 +43,7 @@ public static class IsOrDerivesFromTests
         Action act = () => typeof(object).IsOrDerivesFrom(otherType);
 
         act.Should().Throw<ArgumentNullException>()
-           .And.ParamName.Should().Be(nameof(otherType));
+           .WithParameterName(nameof(otherType));
     }
 
     private static void CheckIsOrDerivesFrom(Type type, Type otherType, bool expected) =>

--- a/Code/Light.GuardClauses.Tests/TypeAssertions/IsOrImplementsTests.cs
+++ b/Code/Light.GuardClauses.Tests/TypeAssertions/IsOrImplementsTests.cs
@@ -29,7 +29,7 @@ public static class IsOrImplementsTests
         Action act = () => type.IsOrImplements(typeof(object));
 
         act.Should().Throw<ArgumentNullException>()
-           .And.ParamName.Should().Be(nameof(type));
+           .WithParameterName(nameof(type));
     }
 
     [Fact]
@@ -41,7 +41,7 @@ public static class IsOrImplementsTests
         Action act = () => typeof(object).IsOrImplements(otherType);
 
         act.Should().Throw<ArgumentNullException>()
-           .And.ParamName.Should().Be(nameof(otherType));
+           .WithParameterName(nameof(otherType));
     }
 
     private static void CheckIsOrImplements(Type type, Type otherType, bool expected) =>

--- a/Code/Light.GuardClauses.Tests/TypeAssertions/IsOrInheritsFromTests.cs
+++ b/Code/Light.GuardClauses.Tests/TypeAssertions/IsOrInheritsFromTests.cs
@@ -31,7 +31,7 @@ public static class IsOrInheritsFromTests
         Action act = () => type.IsOrInheritsFrom(typeof(object));
 
         act.Should().Throw<ArgumentNullException>()
-           .And.ParamName.Should().Be(nameof(type));
+           .WithParameterName(nameof(type));
     }
 
     [Fact]
@@ -43,7 +43,7 @@ public static class IsOrInheritsFromTests
         Action act = () => typeof(object).IsOrInheritsFrom(otherType);
 
         act.Should().Throw<ArgumentNullException>()
-           .And.ParamName.Should().Be(nameof(otherType));
+           .WithParameterName(nameof(otherType));
     }
 
     private static void CheckIsOrInheritsFrom(Type type, Type otherType, bool expected) => type.IsOrInheritsFrom(otherType).Should().Be(expected);

--- a/Code/Light.GuardClauses.Tests/UriAssertions/MustBeAbsoluteUriTests.cs
+++ b/Code/Light.GuardClauses.Tests/UriAssertions/MustBeAbsoluteUriTests.cs
@@ -77,6 +77,6 @@ public static class MustBeAbsoluteUriTests
         var act = () => relativeUri.MustBeAbsoluteUri();
 
         act.Should().Throw<RelativeUriException>()
-           .And.ParamName.Should().Be(nameof(relativeUri));
+           .WithParameterName(nameof(relativeUri));
     }
 }

--- a/Code/Light.GuardClauses.Tests/UriAssertions/MustBeRelativeUriTests.cs
+++ b/Code/Light.GuardClauses.Tests/UriAssertions/MustBeRelativeUriTests.cs
@@ -72,6 +72,6 @@ public static class MustBeRelativeUriTests
         var act = () => absoluteUri.MustBeRelativeUri();
 
         act.Should().Throw<AbsoluteUriException>()
-           .And.ParamName.Should().Be(nameof(absoluteUri));
+           .WithParameterName(nameof(absoluteUri));
     }
 }

--- a/Code/Light.GuardClauses.Tests/UriAssertions/MustHaveOneSchemeOfTests.cs
+++ b/Code/Light.GuardClauses.Tests/UriAssertions/MustHaveOneSchemeOfTests.cs
@@ -90,6 +90,6 @@ public static class MustHaveOneSchemeOfTests
         var act = () => myUrl.MustHaveOneSchemeOf(new[] { "ftp", "ftps" });
 
         act.Should().Throw<InvalidUriSchemeException>()
-           .And.ParamName.Should().Be(nameof(myUrl));
+           .WithParameterName(nameof(myUrl));
     }
 }

--- a/Code/Light.GuardClauses.Tests/UriAssertions/MustHaveSchemeTests.cs
+++ b/Code/Light.GuardClauses.Tests/UriAssertions/MustHaveSchemeTests.cs
@@ -106,6 +106,6 @@ public static class MustHaveSchemeTests
         var act = () => myUrl.MustHaveScheme("ftps");
 
         act.Should().Throw<InvalidUriSchemeException>()
-           .And.ParamName.Should().Be(nameof(myUrl));
+           .WithParameterName(nameof(myUrl));
     }
 }

--- a/Code/Light.GuardClauses/FrameworkExtensions/EnumerableExtensions.cs
+++ b/Code/Light.GuardClauses/FrameworkExtensions/EnumerableExtensions.cs
@@ -163,13 +163,26 @@ public static class EnumerableExtensions
 
         return DetermineCountViaEnumerating(enumerable, parameterName, message);
     }
+    
+    /// <summary>
+    /// Gets the count of the specified enumerable.
+    /// </summary>
+    public static int GetCount<T>(this IEnumerable<T> enumerable) =>
+        enumerable switch
+        {
+            ICollection<T> collectionOfT => collectionOfT.Count,
+            IReadOnlyCollection<T> readOnlyCollectionOfT => readOnlyCollectionOfT.Count,
+            string @string => @string.Length,
+            ICollection collection => collection.Count,
+            _ => DetermineCountViaEnumerating(enumerable)
+        };
 
     private static int DetermineCountViaEnumerating(IEnumerable? enumerable)
     {
         var count = 0;
         var enumerator = enumerable.MustNotBeNull(nameof(enumerable)).GetEnumerator();
         while (enumerator.MoveNext())
-            ++count;
+            count++;
         return count;
     }
 
@@ -178,7 +191,7 @@ public static class EnumerableExtensions
         var count = 0;
         var enumerator = enumerable.MustNotBeNull(parameterName, message).GetEnumerator();
         while (enumerator.MoveNext())
-            ++count;
+            count++;
         return count;
     }
 

--- a/Code/Light.GuardClauses/Range.cs
+++ b/Code/Light.GuardClauses/Range.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using Light.GuardClauses.FrameworkExtensions;
 using System.Runtime.CompilerServices;
@@ -204,8 +205,7 @@ public static class Range
     /// <param name="value">The value that indicates the inclusive lower boundary of the resulting range.</param>
     /// <returns>A value you can use to fluently define the upper boundary of a new range.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Range<T>.RangeFromInfo FromInclusive<T>(T value) where T : IComparable<T> =>
-        new Range<T>.RangeFromInfo(value, true);
+    public static Range<T>.RangeFromInfo FromInclusive<T>(T value) where T : IComparable<T> => new (value, true);
 
     /// <summary>
     /// Use this method to create a range in a fluent style using method chaining.
@@ -214,6 +214,57 @@ public static class Range
     /// <param name="value">The value that indicates the exclusive lower boundary of the resulting range.</param>
     /// <returns>A value you can use to fluently define the upper boundary of a new range.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Range<T>.RangeFromInfo FromExclusive<T>(T value) where T : IComparable<T> =>
-        new Range<T>.RangeFromInfo(value, false); 
+    public static Range<T>.RangeFromInfo FromExclusive<T>(T value) where T : IComparable<T> => new (value, false);
+
+    /// <summary>
+    /// Creates a range for the specified enumerable that encompasses all valid indexes.
+    /// </summary>
+    /// <param name="enumerable">
+    /// The count of this enumerable will be used to create the index range. Please ensure that this enumerable
+    /// is actually a collection, not a lazy enumerable.
+    /// </param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="enumerable"/> is null.</exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Range<int> For(IEnumerable enumerable)  =>
+        new (0, enumerable.Count(), isFromInclusive: true, isToInclusive: false);
+    
+    /// <summary>
+    /// Creates a range for the specified span that encompasses all valid indexes.
+    /// </summary>
+    /// <param name="span">
+    /// The length of the span is used to create a valid index range.
+    /// </param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Range<int> For<T>(ReadOnlySpan<T> span) =>
+        new (0, span.Length, isFromInclusive: true, isToInclusive: false);
+    
+    /// <summary>
+    /// Creates a range for the specified span that encompasses all valid indexes.
+    /// </summary>
+    /// <param name="span">
+    /// The length of the span is used to create a valid index range.
+    /// </param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Range<int> For<T>(Span<T> span) =>
+        new (0 , span.Length, isFromInclusive: true, isToInclusive: false);
+
+    /// <summary>
+    /// Creates a range for the specified memory that encompasses all valid indexes.
+    /// </summary>
+    /// <param name="memory">
+    /// The length of the memory is used to create a valid index range.
+    /// </param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Range<int> For<T>(Memory<T> memory) =>
+        new (0, memory.Length, isFromInclusive: true, isToInclusive: false);
+    
+    /// <summary>
+    /// Creates a range for the specified memory that encompasses all valid indexes.
+    /// </summary>
+    /// <param name="memory">
+    /// The length of the memory is used to create a valid index range.
+    /// </param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Range<int> For<T>(ReadOnlyMemory<T> memory) =>
+        new (0, memory.Length, isFromInclusive: true, isToInclusive: false);
 }

--- a/Code/Light.GuardClauses/Range.cs
+++ b/Code/Light.GuardClauses/Range.cs
@@ -86,7 +86,7 @@ public readonly struct Range<T> : IEquatable<Range<T>> where T : IComparable<T>
     /// <summary>
     /// The nested <see cref="RangeFromInfo" /> can be used to fluently create a <see cref="Range{T}" />.
     /// </summary>
-    public struct RangeFromInfo
+    public readonly struct RangeFromInfo
     {
         private readonly T _from;
         private readonly bool _isFromInclusive;
@@ -225,8 +225,19 @@ public static class Range
     /// </param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="enumerable"/> is null.</exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Range<int> For(IEnumerable enumerable)  =>
+    public static Range<int> For(IEnumerable enumerable) =>
         new (0, enumerable.Count(), isFromInclusive: true, isToInclusive: false);
+    
+    /// <summary>
+    /// Creates a range for the specified enumerable that encompasses all valid indexes.
+    /// </summary>
+    /// <param name="enumerable">
+    /// The count of this enumerable will be used to create the index range. Please ensure that this enumerable
+    /// is actually a collection, not a lazy enumerable.
+    /// </param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="enumerable"/> is null.</exception>
+    public static Range<int> For<T>(IEnumerable<T> enumerable) =>
+        new (0, enumerable.GetCount(), isFromInclusive: true, isToInclusive: false);
     
     /// <summary>
     /// Creates a range for the specified span that encompasses all valid indexes.
@@ -267,4 +278,14 @@ public static class Range
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Range<int> For<T>(ReadOnlyMemory<T> memory) =>
         new (0, memory.Length, isFromInclusive: true, isToInclusive: false);
+    
+    /// <summary>
+    /// Creates a range for the specified memory that encompasses all valid indexes.
+    /// </summary>
+    /// <param name="segment">
+    /// The count of the segment is used to create a valid index range.
+    /// </param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Range<int> For<T>(ArraySegment<T> segment) =>
+        new (0, segment.Count, isFromInclusive: true, isToInclusive: false);
 }


### PR DESCRIPTION
closes https://github.com/feO2x/Light.GuardClauses/issues/93

In addition to the new `Range.For` overloads, I also fixed the tests that break in newer .NET versions (because of enums being extended and `Enumerable.Range` no longer being lazily evaluated).