### PR TITLE
Updates to IsEmailAddress and MustBeEmailAddress

### DIFF
--- a/Code/Light.GuardClauses.Tests/ExecuteReadOnlySpanAssertion.cs
+++ b/Code/Light.GuardClauses.Tests/ExecuteReadOnlySpanAssertion.cs
@@ -1,0 +1,26 @@
+﻿#nullable enable
+using System;
+
+namespace Light.GuardClauses.Tests;
+
+public delegate void ExecuteReadOnlySpanAssertion<T>(
+    ReadOnlySpan<T> span,
+    ReadOnlySpanExceptionFactory<T> exceptionFactory
+);
+
+public delegate void ExecuteSpanAssertion<T>(
+    Span<T> span,
+    ReadOnlySpanExceptionFactory<T> exceptionFactory
+);
+
+public delegate void ExecuteReadOnlySpanAssertion<TItem, TValue>(
+    ReadOnlySpan<TItem> span,
+    TValue additionalValue,
+    ReadOnlySpanExceptionFactory<TItem, TValue> exceptionFactory
+);
+
+public delegate void ExecuteSpanAssertion<TItem, TValue>(
+    Span<TItem> span,
+    TValue additionalValue,
+    ReadOnlySpanExceptionFactory<TItem, TValue> exceptionFactory
+);

--- a/Code/Light.GuardClauses.Tests/StringAssertions/InvalidEmailAddresses.cs
+++ b/Code/Light.GuardClauses.Tests/StringAssertions/InvalidEmailAddresses.cs
@@ -1,0 +1,33 @@
+﻿using Xunit;
+
+namespace Light.GuardClauses.Tests.StringAssertions;
+
+public class InvalidEmailAddresses : TheoryData<string>
+{
+    public InvalidEmailAddresses()
+    {
+        Add("plainaddress");
+        Add("#@%^%#$@#$@#.com");
+        Add("@domain.com");
+        Add("Joe Smith <email@domain.com>");
+        Add("email.domain.com");
+        Add("email@domain@domain.com");
+        Add(".email@domain.com");
+        Add("email.@domain.com");
+        Add("email..email@domain.com");
+        Add("email@domain.com (Joe Smith)");
+        Add("email@domain");
+        Add("email@-domain.com");
+        Add("email@111.222.333.44444");
+        Add("email@domain..com");
+        Add("email@256.256.256.256");
+    }
+}
+
+public sealed class InvalidEmailAddressesWithNull : InvalidEmailAddresses
+{
+    public InvalidEmailAddressesWithNull()
+    {
+        Add(null);
+    }
+}

--- a/Code/Light.GuardClauses.Tests/StringAssertions/IsEmailAddressTests.cs
+++ b/Code/Light.GuardClauses.Tests/StringAssertions/IsEmailAddressTests.cs
@@ -1,27 +1,33 @@
-﻿using FluentAssertions;
+﻿using System;
+using FluentAssertions;
 using Xunit;
 
 namespace Light.GuardClauses.Tests.StringAssertions;
 
 public sealed class IsEmailAddressTests
 {
+    public static readonly TheoryData<string> InvalidEmailAddresses =
+    [
+        null,
+        "plainaddress",
+        "#@%^%#$@#$@#.com",
+        "@domain.com",
+        "Joe Smith <email@domain.com>",
+        "email.domain.com",
+        "email@domain@domain.com",
+        ".email@domain.com",
+        "email.@domain.com",
+        "email..email@domain.com",
+        "email@domain.com (Joe Smith)",
+        "email@domain",
+        "email@-domain.com",
+        "email@111.222.333.44444",
+        "email@domain..com",
+        "email@256.256.256.256",
+    ];
+
     [Theory]
-    [InlineData(null)]
-    [InlineData("plainaddress")]
-    [InlineData("#@%^%#$@#$@#.com")]
-    [InlineData("@domain.com")]
-    [InlineData("Joe Smith <email@domain.com>")]
-    [InlineData("email.domain.com")]
-    [InlineData("email@domain@domain.com")]
-    [InlineData(".email@domain.com")]
-    [InlineData("email.@domain.com")]
-    [InlineData("email..email@domain.com")]
-    [InlineData("email@domain.com (Joe Smith)")]
-    [InlineData("email@domain")]
-    [InlineData("email@-domain.com")]
-    [InlineData("email@111.222.333.44444")]
-    [InlineData("email@domain..com")]
-    [InlineData("email@256.256.256.256")] // Invalid IP (values > 255)
+    [MemberData(nameof(InvalidEmailAddresses))]
     public void IsNotValidEmailAddress(string email)
     {
         var isValid = email.IsEmailAddress();
@@ -29,29 +35,116 @@ public sealed class IsEmailAddressTests
         isValid.Should().BeFalse();
     }
 
+    public static readonly TheoryData<string> ValidEmailAddresses =
+    [
+        "email@domain.com",
+        "firstname.lastname@domain.com",
+        "email@subdomain.domain.com",
+        "firstname+lastname@domain.com",
+        "email@123.123.123.123",
+        "1234567890@domain.com",
+        "email@domain-one.com",
+        "_______@domain.com",
+        "email@domain.name",
+        "email@domain.co.jp",
+        "firstname-lastname@domain.com",
+        "email@domain.museum", // Long TLD (>4 chars)
+        "email@domain.travel", // Another long TLD
+        "email@domain.photography", // Even longer TLD
+        "email@[IPv6:2001:db8::1]", // IPv6 format
+        "\"quoted\"@domain.com", // Quoted local part
+        "user.name+tag+sorting@example.com", // Gmail-style + addressing
+        "あいうえお@domain.com", // Unicode character test
+    ];
+
     [Theory]
-    [InlineData("email@domain.com")]
-    [InlineData("firstname.lastname@domain.com")]
-    [InlineData("email@subdomain.domain.com")]
-    [InlineData("firstname+lastname@domain.com")]
-    [InlineData("email@123.123.123.123")]
-    [InlineData("1234567890@domain.com")]
-    [InlineData("email@domain-one.com")]
-    [InlineData("_______@domain.com")]
-    [InlineData("email@domain.name")]
-    [InlineData("email@domain.co.jp")]
-    [InlineData("firstname-lastname@domain.com")]
-    [InlineData("email@domain.museum")] // Long TLD (>4 chars)
-    [InlineData("email@domain.travel")] // Another long TLD
-    [InlineData("email@domain.photography")] // Even longer TLD
-    [InlineData("email@[IPv6:2001:db8::1]")] // IPv6 format
-    [InlineData("\"quoted\"@domain.com")] // Quoted local part
-    [InlineData("user.name+tag+sorting@example.com")] // Gmail-style + addressing
-    [InlineData("あいうえお@domain.com")] // Unicode character test
+    [MemberData(nameof(ValidEmailAddresses))]
     public void IsValidEmailAddress(string email)
     {
         var isValid = email.IsEmailAddress();
 
         isValid.Should().BeTrue();
     }
+
+#if NET8_0
+    [Theory]
+    [MemberData(nameof(InvalidEmailAddresses))]
+    public void IsNotValidEmailAddress_ReadOnlySpan(string email)
+    {
+        var span = new ReadOnlySpan<char>(email?.ToCharArray() ?? []);
+        var isValid = span.IsEmailAddress();
+
+        isValid.Should().BeFalse();
+    }
+
+    [Theory]
+    [MemberData(nameof(ValidEmailAddresses))]
+    public void IsValidEmailAddress_ReadOnlySpan(string email)
+    {
+        var span = email.AsSpan();
+        var isValid = span.IsEmailAddress();
+
+        isValid.Should().BeTrue();
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidEmailAddresses))]
+    public void IsNotValidEmailAddress_Span(string email)
+    {
+        var span = new Span<char>(email?.ToCharArray() ?? []);
+        var isValid = span.IsEmailAddress();
+
+        isValid.Should().BeFalse();
+    }
+
+    [Theory]
+    [MemberData(nameof(ValidEmailAddresses))]
+    public void IsValidEmailAddress_Span(string email)
+    {
+        var span = new Span<char>(email.ToCharArray());
+        var isValid = span.IsEmailAddress();
+
+        isValid.Should().BeTrue();
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidEmailAddresses))]
+    public void IsNotValidEmailAddress_Memory(string email)
+    {
+        var memory = email?.ToCharArray().AsMemory() ?? Memory<char>.Empty;
+        var isValid = memory.IsEmailAddress();
+
+        isValid.Should().BeFalse();
+    }
+
+    [Theory]
+    [MemberData(nameof(ValidEmailAddresses))]
+    public void IsValidEmailAddress_Memory(string email)
+    {
+        var memory = email.ToCharArray().AsMemory();
+        var isValid = memory.IsEmailAddress();
+
+        isValid.Should().BeTrue();
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidEmailAddresses))]
+    public void IsNotValidEmailAddress_ReadOnlyMemory(string email)
+    {
+        var memory = new ReadOnlyMemory<char>(email?.ToCharArray() ?? []);
+        var isValid = memory.IsEmailAddress();
+
+        isValid.Should().BeFalse();
+    }
+
+    [Theory]
+    [MemberData(nameof(ValidEmailAddresses))]
+    public void IsValidEmailAddress_ReadOnlyMemory(string email)
+    {
+        var memory = new ReadOnlyMemory<char>(email.ToCharArray());
+        var isValid = memory.IsEmailAddress();
+
+        isValid.Should().BeTrue();
+    }
+#endif
 }

--- a/Code/Light.GuardClauses.Tests/StringAssertions/IsEmailAddressTests.cs
+++ b/Code/Light.GuardClauses.Tests/StringAssertions/IsEmailAddressTests.cs
@@ -3,7 +3,7 @@ using Xunit;
 
 namespace Light.GuardClauses.Tests.StringAssertions;
 
-public sealed class IsEmailAddressTest
+public sealed class IsEmailAddressTests
 {
     [Theory]
     [InlineData(null)]
@@ -16,12 +16,12 @@ public sealed class IsEmailAddressTest
     [InlineData(".email@domain.com")]
     [InlineData("email.@domain.com")]
     [InlineData("email..email@domain.com")]
-    [InlineData("あいうえお@domain.com")]
     [InlineData("email@domain.com (Joe Smith)")]
     [InlineData("email@domain")]
     [InlineData("email@-domain.com")]
     [InlineData("email@111.222.333.44444")]
     [InlineData("email@domain..com")]
+    [InlineData("email@256.256.256.256")] // Invalid IP (values > 255)
     public void IsNotValidEmailAddress(string email)
     {
         var isValid = email.IsEmailAddress();
@@ -41,6 +41,13 @@ public sealed class IsEmailAddressTest
     [InlineData("email@domain.name")]
     [InlineData("email@domain.co.jp")]
     [InlineData("firstname-lastname@domain.com")]
+    [InlineData("email@domain.museum")] // Long TLD (>4 chars)
+    [InlineData("email@domain.travel")] // Another long TLD
+    [InlineData("email@domain.photography")] // Even longer TLD
+    [InlineData("email@[IPv6:2001:db8::1]")] // IPv6 format
+    [InlineData("\"quoted\"@domain.com")] // Quoted local part
+    [InlineData("user.name+tag+sorting@example.com")] // Gmail-style + addressing
+    [InlineData("あいうえお@domain.com")] // Unicode character test
     public void IsValidEmailAddress(string email)
     {
         var isValid = email.IsEmailAddress();

--- a/Code/Light.GuardClauses.Tests/StringAssertions/IsEmailAddressTests.cs
+++ b/Code/Light.GuardClauses.Tests/StringAssertions/IsEmailAddressTests.cs
@@ -6,28 +6,8 @@ namespace Light.GuardClauses.Tests.StringAssertions;
 
 public sealed class IsEmailAddressTests
 {
-    public static readonly TheoryData<string> InvalidEmailAddresses =
-    [
-        null,
-        "plainaddress",
-        "#@%^%#$@#$@#.com",
-        "@domain.com",
-        "Joe Smith <email@domain.com>",
-        "email.domain.com",
-        "email@domain@domain.com",
-        ".email@domain.com",
-        "email.@domain.com",
-        "email..email@domain.com",
-        "email@domain.com (Joe Smith)",
-        "email@domain",
-        "email@-domain.com",
-        "email@111.222.333.44444",
-        "email@domain..com",
-        "email@256.256.256.256",
-    ];
-
     [Theory]
-    [MemberData(nameof(InvalidEmailAddresses))]
+    [ClassData(typeof(InvalidEmailAddressesWithNull))]
     public void IsNotValidEmailAddress(string email)
     {
         var isValid = email.IsEmailAddress();
@@ -35,30 +15,8 @@ public sealed class IsEmailAddressTests
         isValid.Should().BeFalse();
     }
 
-    public static readonly TheoryData<string> ValidEmailAddresses =
-    [
-        "email@domain.com",
-        "firstname.lastname@domain.com",
-        "email@subdomain.domain.com",
-        "firstname+lastname@domain.com",
-        "email@123.123.123.123",
-        "1234567890@domain.com",
-        "email@domain-one.com",
-        "_______@domain.com",
-        "email@domain.name",
-        "email@domain.co.jp",
-        "firstname-lastname@domain.com",
-        "email@domain.museum", // Long TLD (>4 chars)
-        "email@domain.travel", // Another long TLD
-        "email@domain.photography", // Even longer TLD
-        "email@[IPv6:2001:db8::1]", // IPv6 format
-        "\"quoted\"@domain.com", // Quoted local part
-        "user.name+tag+sorting@example.com", // Gmail-style + addressing
-        "あいうえお@domain.com", // Unicode character test
-    ];
-
     [Theory]
-    [MemberData(nameof(ValidEmailAddresses))]
+    [ClassData(typeof(ValidEmailAddresses))]
     public void IsValidEmailAddress(string email)
     {
         var isValid = email.IsEmailAddress();
@@ -68,7 +26,7 @@ public sealed class IsEmailAddressTests
 
 #if NET8_0
     [Theory]
-    [MemberData(nameof(InvalidEmailAddresses))]
+    [ClassData(typeof(InvalidEmailAddressesWithNull))]
     public void IsNotValidEmailAddress_ReadOnlySpan(string email)
     {
         var span = new ReadOnlySpan<char>(email?.ToCharArray() ?? []);
@@ -78,7 +36,7 @@ public sealed class IsEmailAddressTests
     }
 
     [Theory]
-    [MemberData(nameof(ValidEmailAddresses))]
+    [ClassData(typeof(ValidEmailAddresses))]
     public void IsValidEmailAddress_ReadOnlySpan(string email)
     {
         var span = email.AsSpan();
@@ -88,7 +46,7 @@ public sealed class IsEmailAddressTests
     }
 
     [Theory]
-    [MemberData(nameof(InvalidEmailAddresses))]
+    [ClassData(typeof(InvalidEmailAddressesWithNull))]
     public void IsNotValidEmailAddress_Span(string email)
     {
         var span = new Span<char>(email?.ToCharArray() ?? []);
@@ -98,7 +56,7 @@ public sealed class IsEmailAddressTests
     }
 
     [Theory]
-    [MemberData(nameof(ValidEmailAddresses))]
+    [ClassData(typeof(ValidEmailAddresses))]
     public void IsValidEmailAddress_Span(string email)
     {
         var span = new Span<char>(email.ToCharArray());
@@ -108,7 +66,7 @@ public sealed class IsEmailAddressTests
     }
 
     [Theory]
-    [MemberData(nameof(InvalidEmailAddresses))]
+    [ClassData(typeof(InvalidEmailAddressesWithNull))]
     public void IsNotValidEmailAddress_Memory(string email)
     {
         var memory = email?.ToCharArray().AsMemory() ?? Memory<char>.Empty;
@@ -118,7 +76,7 @@ public sealed class IsEmailAddressTests
     }
 
     [Theory]
-    [MemberData(nameof(ValidEmailAddresses))]
+    [ClassData(typeof(ValidEmailAddresses))]
     public void IsValidEmailAddress_Memory(string email)
     {
         var memory = email.ToCharArray().AsMemory();
@@ -128,7 +86,7 @@ public sealed class IsEmailAddressTests
     }
 
     [Theory]
-    [MemberData(nameof(InvalidEmailAddresses))]
+    [ClassData(typeof(InvalidEmailAddressesWithNull))]
     public void IsNotValidEmailAddress_ReadOnlyMemory(string email)
     {
         var memory = new ReadOnlyMemory<char>(email?.ToCharArray() ?? []);
@@ -138,7 +96,7 @@ public sealed class IsEmailAddressTests
     }
 
     [Theory]
-    [MemberData(nameof(ValidEmailAddresses))]
+    [ClassData(typeof(ValidEmailAddresses))]
     public void IsValidEmailAddress_ReadOnlyMemory(string email)
     {
         var memory = new ReadOnlyMemory<char>(email.ToCharArray());

--- a/Code/Light.GuardClauses.Tests/StringAssertions/MustBeEmailAddressTests.cs
+++ b/Code/Light.GuardClauses.Tests/StringAssertions/MustBeEmailAddressTests.cs
@@ -9,35 +9,36 @@ namespace Light.GuardClauses.Tests.StringAssertions;
 public static class MustBeEmailAddressTests
 {
     [Theory]
-    [InlineData("email@domain.com")]
-    [InlineData("email@123.123.123.123")]
-    public static void ValidEmailAddress(string emailAddress) => emailAddress.MustBeEmailAddress().Should().BeSameAs(emailAddress);
+    [ClassData(typeof(ValidEmailAddresses))]
+    public static void ValidEmailAddress(string emailAddress) =>
+        emailAddress.MustBeEmailAddress().Should().BeSameAs(emailAddress);
 
     [Theory]
-    [InlineData("plainAddress")]
-    [InlineData("Joe Smith <email@domain.com>")]
+    [ClassData(typeof(InvalidEmailAddresses))]
     public static void InvalidEmailAddress(string emailAddress)
     {
         Action act = () => emailAddress.MustBeEmailAddress();
 
         act.Should().Throw<InvalidEmailAddressException>()
-           .And.Message.Should().Contain($"emailAddress must be a valid email address, but it actually is \"{emailAddress}\".");
+           .And.Message.Should().Contain(
+                $"emailAddress must be a valid email address, but it actually is \"{emailAddress}\"."
+            );
     }
 
     [Theory]
-    [InlineData(".email@domain.com")]
-    [InlineData("email.@domain.com")]
+    [ClassData(typeof(InvalidEmailAddresses))]
     public static void InvalidEmailAddressArgumentName(string emailAddress)
     {
         Action act = () => emailAddress.MustBeEmailAddress(nameof(emailAddress));
 
         act.Should().Throw<InvalidEmailAddressException>()
-           .And.Message.Should().Contain($"emailAddress must be a valid email address, but it actually is \"{emailAddress}\".");
+           .And.Message.Should().Contain(
+                $"emailAddress must be a valid email address, but it actually is \"{emailAddress}\"."
+            );
     }
 
     [Theory]
-    [InlineData("email@domain")]
-    [InlineData("email@-domain.com")]
+    [ClassData(typeof(InvalidEmailAddresses))]
     public static void InvalidEmailAddressCustomMessage(string emailAddress)
     {
         const string customMessage = "This email address is not valid";
@@ -55,7 +56,7 @@ public static class MustBeEmailAddressTests
     {
         const string email = "email@domain@domain.com";
 
-        Action act = () => email.MustBeEmailAddress(CustomRegex, "email");
+        Action act = () => email.MustBeEmailAddress(CustomRegex);
 
         act.Should().Throw<InvalidEmailAddressException>()
            .And.Message.Should().Contain($"email must be a valid email address, but it actually is \"{email}\".");
@@ -82,27 +83,35 @@ public static class MustBeEmailAddressTests
         new ()
         {
             { null, CustomRegex },
-            { "invalidEmailAddress", null }
+            { "invalidEmailAddress", null },
         };
 
     [Fact]
     public static void CustomException() =>
-        Test.CustomException("email.domain.com",
-                             (input, exceptionFactory) => input.MustBeEmailAddress(exceptionFactory));
+        Test.CustomException(
+            "email.domain.com",
+            (input, exceptionFactory) => input.MustBeEmailAddress(exceptionFactory)
+        );
 
     [Fact]
     public static void CustomMessage() =>
-        Test.CustomMessage<InvalidEmailAddressException>(message => "#@%^%#$@#$@#.com".MustBeEmailAddress(message: message));
+        Test.CustomMessage<InvalidEmailAddressException>(
+            message => "#@%^%#$@#$@#.com".MustBeEmailAddress(message: message)
+        );
 
     [Fact]
     public static void CustomExceptionCustomRegex() =>
-        Test.CustomException("invalidEmailAddress",
-                             CustomRegex,
-                             (i, r, exceptionFactory) => i.MustBeEmailAddress(r, exceptionFactory));
+        Test.CustomException(
+            "invalidEmailAddress",
+            CustomRegex,
+            (i, r, exceptionFactory) => i.MustBeEmailAddress(r, exceptionFactory)
+        );
 
     [Fact]
     public static void CustomMessageCustomRegex() =>
-        Test.CustomMessage<InvalidEmailAddressException>(message => "invalidEmailAddress".MustBeEmailAddress(CustomRegex, message: message));
+        Test.CustomMessage<InvalidEmailAddressException>(
+            message => "invalidEmailAddress".MustBeEmailAddress(CustomRegex, message: message)
+        );
 
     [Fact]
     public static void CallerArgumentExpression()
@@ -114,4 +123,346 @@ public static class MustBeEmailAddressTests
         act.Should().Throw<InvalidEmailAddressException>()
            .WithParameterName(nameof(email));
     }
+
+#if NET8_0
+    [Theory]
+    [ClassData(typeof(ValidEmailAddresses))]
+    public static void ValidEmailAddress_ReadOnlySpan(string email)
+    {
+        var result = email.AsSpan().MustBeEmailAddress();
+        result.ToString().Should().Be(email);
+    }
+
+    [Theory]
+    [ClassData(typeof(InvalidEmailAddresses))]
+    public static void InvalidEmailAddress_ReadOnlySpan(string email)
+    {
+        var act = () =>
+        {
+            var readOnlySpan = email.AsSpan();
+            readOnlySpan.MustBeEmailAddress();
+        };
+        act.Should().Throw<InvalidEmailAddressException>()
+           .And.Message.Should()
+           .Contain($"readOnlySpan must be a valid email address, but it actually is \"{email}\".");
+    }
+
+    [Theory]
+    [ClassData(typeof(InvalidEmailAddresses))]
+    public static void InvalidEmailAddressArgumentName_ReadOnlySpan(string email)
+    {
+        Action act = () => email.AsSpan().MustBeEmailAddress(nameof(email));
+        act.Should().Throw<InvalidEmailAddressException>()
+           .And.Message.Should().Contain(nameof(email));
+    }
+
+    [Theory]
+    [ClassData(typeof(InvalidEmailAddresses))]
+    public static void InvalidEmailAddressCustomMessage_ReadOnlySpan(string email)
+    {
+        const string customMessage = "This email address is not valid";
+        Action act = () => email.AsSpan().MustBeEmailAddress(nameof(email), customMessage);
+        act.Should().Throw<InvalidEmailAddressException>()
+           .And.Message.Should().Contain(customMessage);
+    }
+
+    [Fact]
+    public static void CallerArgumentExpression_ReadOnlySpan()
+    {
+        var act = () =>
+        {
+            var email = "This is not an email address".AsSpan();
+            email.MustBeEmailAddress();
+        };
+        act.Should().Throw<InvalidEmailAddressException>()
+           .WithParameterName("email");
+    }
+
+    [Fact]
+    public static void CustomException_ReadOnlySpan() =>
+        Test.CustomSpanException(
+            "email.domain.com".AsSpan(),
+            (input, exceptionFactory) => input.MustBeEmailAddress(exceptionFactory)
+        );
+
+    [Fact]
+    public static void CustomExceptionCustomRegex_ReadOnlySpan() =>
+        Test.CustomSpanException(
+            "invalidEmailAddress".AsSpan(),
+            CustomRegex,
+            (i, r, exceptionFactory) => i.MustBeEmailAddress(r, exceptionFactory)
+        );
+
+    [Fact]
+    public static void CustomMessageCustomRegex_ReadOnlySpan() =>
+        Test.CustomMessage<InvalidEmailAddressException>(
+            message => "invalidEmailAddress".AsSpan().MustBeEmailAddress(CustomRegex, message: message)
+        );
+
+    // Tests for Span<char>
+    [Theory]
+    [ClassData(typeof(ValidEmailAddresses))]
+    public static void ValidEmailAddress_Span(string email)
+    {
+        var emailChars = email.ToCharArray();
+        var span = new Span<char>(emailChars);
+        var result = span.MustBeEmailAddress();
+        new string(result).Should().Be(email);
+    }
+
+    [Theory]
+    [ClassData(typeof(InvalidEmailAddresses))]
+    public static void InvalidEmailAddress_Span(string email)
+    {
+        var emailChars = email.ToCharArray();
+        var act = () =>
+        {
+            var span = new Span<char>(emailChars);
+            span.MustBeEmailAddress();
+        };
+        act.Should().Throw<InvalidEmailAddressException>()
+           .And.Message.Should().Contain($"span must be a valid email address, but it actually is \"{email}\".");
+    }
+
+    [Theory]
+    [ClassData(typeof(InvalidEmailAddresses))]
+    public static void InvalidEmailAddressArgumentName_Span(string email)
+    {
+        var emailChars = email.ToCharArray();
+        var act = () =>
+        {
+            var span = new Span<char>(emailChars);
+            span.MustBeEmailAddress(nameof(span));
+        };
+        act.Should().Throw<InvalidEmailAddressException>()
+           .And.Message.Should().Contain("span");
+    }
+
+    [Theory]
+    [ClassData(typeof(InvalidEmailAddresses))]
+    public static void InvalidEmailAddressCustomMessage_Span(string email)
+    {
+        const string customMessage = "This email address is not valid";
+        var emailChars = email.ToCharArray();
+        var act = () =>
+        {
+            var span = new Span<char>(emailChars);
+            span.MustBeEmailAddress(nameof(span), customMessage);
+        };
+        act.Should().Throw<InvalidEmailAddressException>()
+           .And.Message.Should().Contain(customMessage);
+    }
+
+    [Fact]
+    public static void CallerArgumentExpression_Span()
+    {
+        var act = () =>
+        {
+            var emailChars = "This is not an email address".ToCharArray();
+            var span = new Span<char>(emailChars);
+            span.MustBeEmailAddress();
+        };
+        act.Should().Throw<InvalidEmailAddressException>()
+           .WithParameterName("span");
+    }
+
+    [Fact]
+    public static void CustomException_Span()
+    {
+        var emailChars = "email.domain.com".ToCharArray();
+        var span = new Span<char>(emailChars);
+        Test.CustomSpanException(
+            span,
+            (input, exceptionFactory) => input.MustBeEmailAddress(exceptionFactory)
+        );
+    }
+
+    [Fact]
+    public static void CustomExceptionCustomRegex_Span()
+    {
+        var emailChars = "invalidEmailAddress".ToCharArray();
+        var span = new Span<char>(emailChars);
+        Test.CustomSpanException(
+            span,
+            CustomRegex,
+            (i, r, exceptionFactory) => i.MustBeEmailAddress(r, exceptionFactory)
+        );
+    }
+
+    [Fact]
+    public static void CustomMessageCustomRegex_Span() =>
+        Test.CustomMessage<InvalidEmailAddressException>(
+            message =>
+            {
+                var span = new Span<char>("invalidEmailAddress".ToCharArray());
+                span.MustBeEmailAddress(CustomRegex, message: message);
+            }
+        );
+
+    // Tests for Memory<char>
+    [Theory]
+    [ClassData(typeof(ValidEmailAddresses))]
+    public static void ValidEmailAddress_Memory(string email)
+    {
+        var memory = email.ToCharArray().AsMemory();
+        var result = memory.MustBeEmailAddress();
+        result.ToString().Should().Be(email);
+    }
+
+    [Theory]
+    [ClassData(typeof(InvalidEmailAddresses))]
+    public static void InvalidEmailAddress_Memory(string email)
+    {
+        var memory = email.ToCharArray().AsMemory();
+        Action act = () => memory.MustBeEmailAddress();
+        act.Should().Throw<InvalidEmailAddressException>()
+           .And.Message.Should().Contain($"memory must be a valid email address, but it actually is \"{email}\".");
+    }
+
+    [Theory]
+    [ClassData(typeof(InvalidEmailAddresses))]
+    public static void InvalidEmailAddressArgumentName_Memory(string email)
+    {
+        var memory = email.ToCharArray().AsMemory();
+        Action act = () => memory.MustBeEmailAddress(nameof(memory));
+        act.Should().Throw<InvalidEmailAddressException>()
+           .And.Message.Should().Contain(nameof(memory));
+    }
+
+    [Theory]
+    [ClassData(typeof(InvalidEmailAddresses))]
+    public static void InvalidEmailAddressCustomMessage_Memory(string email)
+    {
+        const string customMessage = "This email address is not valid";
+        var memory = email.ToCharArray().AsMemory();
+        Action act = () => memory.MustBeEmailAddress(nameof(memory), customMessage);
+        act.Should().Throw<InvalidEmailAddressException>()
+           .And.Message.Should().Contain(customMessage);
+    }
+
+    [Fact]
+    public static void CallerArgumentExpression_Memory()
+    {
+        var act = () =>
+        {
+            var memory = "This is not an email address".ToCharArray().AsMemory();
+            memory.MustBeEmailAddress();
+        };
+        act.Should().Throw<InvalidEmailAddressException>()
+           .WithParameterName("memory");
+    }
+
+    [Fact]
+    public static void CustomException_Memory()
+    {
+        var memory = "email.domain.com".ToCharArray().AsMemory();
+        Test.CustomMemoryException(
+            memory,
+            (input, exceptionFactory) => input.MustBeEmailAddress(exceptionFactory)
+        );
+    }
+
+    [Fact]
+    public static void CustomExceptionCustomRegex_Memory()
+    {
+        var memory = "invalidEmailAddress".ToCharArray().AsMemory();
+        Test.CustomMemoryException(
+            memory,
+            CustomRegex,
+            (i, r, exceptionFactory) => i.MustBeEmailAddress(r, exceptionFactory)
+        );
+    }
+
+    [Fact]
+    public static void CustomMessageCustomRegex_Memory()
+    {
+        var memory = "invalidEmailAddress".AsMemory();
+        Test.CustomMessage<InvalidEmailAddressException>(
+            message => memory.MustBeEmailAddress(CustomRegex, message: message)
+        );
+    }
+
+    // Tests for ReadOnlyMemory<char>
+    [Theory]
+    [ClassData(typeof(ValidEmailAddresses))]
+    public static void ValidEmailAddress_ReadOnlyMemory(string email)
+    {
+        var memory = email.AsMemory();
+        var result = memory.MustBeEmailAddress();
+        result.ToString().Should().Be(email);
+    }
+
+    [Theory]
+    [ClassData(typeof(InvalidEmailAddresses))]
+    public static void InvalidEmailAddress_ReadOnlyMemory(string email)
+    {
+        var memory = email.AsMemory();
+        Action act = () => memory.MustBeEmailAddress();
+        act.Should().Throw<InvalidEmailAddressException>()
+           .And.Message.Should().StartWith($"memory must be a valid email address, but it actually is \"{email}\".");
+    }
+
+    [Theory]
+    [ClassData(typeof(InvalidEmailAddresses))]
+    public static void InvalidEmailAddressArgumentName_ReadOnlyMemory(string email)
+    {
+        var readOnlyMemory = email.AsMemory();
+        Action act = () => readOnlyMemory.MustBeEmailAddress(nameof(readOnlyMemory));
+        act.Should().Throw<InvalidEmailAddressException>()
+           .And.Message.Should().Contain(nameof(readOnlyMemory));
+    }
+
+    [Theory]
+    [ClassData(typeof(InvalidEmailAddresses))]
+    public static void InvalidEmailAddressCustomMessage_ReadOnlyMemory(string email)
+    {
+        const string customMessage = "This email address is not valid";
+        var readOnlyMemory = email.AsMemory();
+        Action act = () => readOnlyMemory.MustBeEmailAddress(nameof(readOnlyMemory), customMessage);
+        act.Should().Throw<InvalidEmailAddressException>()
+           .And.Message.Should().Contain(customMessage);
+    }
+
+    [Fact]
+    public static void CallerArgumentExpression_ReadOnlyMemory()
+    {
+        var act = () =>
+        {
+            var readOnlyMemory = "This is not an email address".AsMemory();
+            readOnlyMemory.MustBeEmailAddress();
+        };
+        act.Should().Throw<InvalidEmailAddressException>()
+           .WithParameterName("readOnlyMemory");
+    }
+
+    [Fact]
+    public static void CustomException_ReadOnlyMemory()
+    {
+        var readOnlyMemory = "email.domain.com".AsMemory();
+        Test.CustomMemoryException(
+            readOnlyMemory,
+            (input, exceptionFactory) => input.MustBeEmailAddress(exceptionFactory)
+        );
+    }
+
+    [Fact]
+    public static void CustomExceptionCustomRegex_ReadOnlyMemory()
+    {
+        var readOnlyMemory = "invalidEmailAddress".AsMemory();
+        Test.CustomMemoryException(
+            readOnlyMemory,
+            CustomRegex,
+            (i, r, exceptionFactory) => i.MustBeEmailAddress(r, exceptionFactory)
+        );
+    }
+
+    [Fact]
+    public static void CustomMessageCustomRegex_ReadOnlyMemory()
+    {
+        var readOnlyMemory = "invalidEmailAddress".AsMemory();
+        Test.CustomMessage<InvalidEmailAddressException>(
+            message => readOnlyMemory.MustBeEmailAddress(CustomRegex, message: message)
+        );
+    }
+#endif
 }

--- a/Code/Light.GuardClauses.Tests/StringAssertions/ValidEmailAddresses.cs
+++ b/Code/Light.GuardClauses.Tests/StringAssertions/ValidEmailAddresses.cs
@@ -1,0 +1,28 @@
+﻿using Xunit;
+
+namespace Light.GuardClauses.Tests.StringAssertions;
+
+public sealed class ValidEmailAddresses : TheoryData<string>
+{
+    public ValidEmailAddresses()
+    {
+        Add("email@domain.com");
+        Add("firstname.lastname@domain.com");
+        Add("email@subdomain.domain.com");
+        Add("firstname+lastname@domain.com");
+        Add("email@123.123.123.123");
+        Add("1234567890@domain.com");
+        Add("email@domain-one.com");
+        Add("_______@domain.com");
+        Add("email@domain.name");
+        Add("email@domain.co.jp");
+        Add("firstname-lastname@domain.com");
+        Add("email@domain.museum"); // Long TLD (>4 chars)
+        Add("email@domain.travel"); // Another long TLD
+        Add("email@domain.photography"); // Even longer TLD
+        Add("email@[IPv6:2001:db8::1]"); // IPv6 format
+        Add("\"quoted\"@domain.com"); // Quoted local part
+        Add("user.name+tag+sorting@example.com"); // Gmail-style + addressing
+        Add("あいうえお@domain.com"); // Unicode character test
+    }
+}

--- a/Code/Light.GuardClauses.Tests/Test.cs
+++ b/Code/Light.GuardClauses.Tests/Test.cs
@@ -1,10 +1,10 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using FluentAssertions;
 using FluentAssertions.Specialized;
 using Xunit.Abstractions;
 using Xunit.Sdk;
-
-#nullable enable
 
 namespace Light.GuardClauses.Tests;
 
@@ -48,7 +48,108 @@ public static class Test
         }
     }
 
-    public static void CustomException<T1, T2>(T1 first, T2 second, Action<T1, T2, Func<T1, T2, Exception>> executeAssertion)
+    public static void CustomSpanException<T>(
+        ReadOnlySpan<T> invalidValue,
+        ExecuteReadOnlySpanAssertion<T> executeAssertion
+    )
+    {
+        T[]? capturedParameter = null;
+
+        Exception ExceptionFactory(ReadOnlySpan<T> parameter)
+        {
+            capturedParameter = parameter.ToArray();
+            return Exception;
+        }
+
+        try
+        {
+            executeAssertion(invalidValue, ExceptionFactory);
+            throw new XunitException("The assertion should have thrown a custom exception at this point.");
+        }
+        catch (ExceptionDummy exception)
+        {
+            exception.Should().BeSameAs(exception);
+            capturedParameter.Should().Equal(invalidValue.ToArray());
+        }
+    }
+
+    public static void CustomSpanException<T>(Span<T> invalidValue, ExecuteSpanAssertion<T> executeAssertion)
+    {
+        T[]? capturedParameter = null;
+
+        Exception ExceptionFactory(ReadOnlySpan<T> parameter)
+        {
+            capturedParameter = parameter.ToArray();
+            return Exception;
+        }
+
+        try
+        {
+            executeAssertion(invalidValue, ExceptionFactory);
+            throw new XunitException("The assertion should have thrown a custom exception at this point.");
+        }
+        catch (ExceptionDummy exception)
+        {
+            exception.Should().BeSameAs(exception);
+            capturedParameter.Should().Equal(invalidValue.ToArray());
+        }
+    }
+
+    public static void CustomMemoryException<T>(
+        Memory<T> invalidValue,
+        Action<Memory<T>, ReadOnlySpanExceptionFactory<T>> executeAssertion
+    )
+    {
+        Memory<T> capturedParameter = default;
+
+        Exception ExceptionFactory(ReadOnlySpan<T> parameter)
+        {
+            capturedParameter = parameter.ToArray();
+            return Exception;
+        }
+
+        try
+        {
+            executeAssertion(invalidValue, ExceptionFactory);
+            throw new XunitException("The assertion should have thrown a custom exception at this point.");
+        }
+        catch (ExceptionDummy exception)
+        {
+            exception.Should().BeSameAs(exception);
+            capturedParameter.ToArray().Should().Equal(invalidValue.ToArray());
+        }
+    }
+
+    public static void CustomMemoryException<T>(
+        ReadOnlyMemory<T> invalidValue,
+        Action<ReadOnlyMemory<T>, ReadOnlySpanExceptionFactory<T>> executeAssertion
+    )
+    {
+        ReadOnlyMemory<T> capturedParameter = default;
+
+        Exception ExceptionFactory(ReadOnlySpan<T> parameter)
+        {
+            capturedParameter = parameter.ToArray();
+            return Exception;
+        }
+
+        try
+        {
+            executeAssertion(invalidValue, ExceptionFactory);
+            throw new XunitException("The assertion should have thrown a custom exception at this point.");
+        }
+        catch (ExceptionDummy exception)
+        {
+            exception.Should().BeSameAs(exception);
+            capturedParameter.ToArray().Should().Equal(invalidValue.ToArray());
+        }
+    }
+
+    public static void CustomException<T1, T2>(
+        T1 first,
+        T2 second,
+        Action<T1, T2, Func<T1, T2, Exception>> executeAssertion
+    )
     {
         T1? capturedFirst = default;
         T2? capturedSecond = default;
@@ -73,7 +174,128 @@ public static class Test
         }
     }
 
-    public static void CustomException<T1, T2, T3>(T1 first, T2 second, T3 third, Action<T1, T2, T3, Func<T1, T2, T3, Exception>> executeAssertion)
+    public static void CustomSpanException<T1, T2>(
+        ReadOnlySpan<T1> invalidValue,
+        T2 additionalValue,
+        ExecuteReadOnlySpanAssertion<T1, T2> executeAssertion
+    )
+    {
+        T1[]? capturedFirst = null;
+        T2? capturedSecond = default;
+
+        Exception ExceptionFactory(ReadOnlySpan<T1> parameter, T2 second)
+        {
+            capturedFirst = parameter.ToArray();
+            capturedSecond = second;
+            return Exception;
+        }
+
+        try
+        {
+            executeAssertion(invalidValue, additionalValue, ExceptionFactory);
+            throw new XunitException("The assertion should have thrown a custom exception at this point.");
+        }
+        catch (ExceptionDummy exception)
+        {
+            exception.Should().BeSameAs(exception);
+            capturedFirst.Should().Equal(invalidValue.ToArray());
+            capturedSecond.Should().Be(additionalValue);
+        }
+    }
+
+    public static void CustomSpanException<T1, T2>(
+        Span<T1> invalidValue,
+        T2 additionalValue,
+        ExecuteSpanAssertion<T1, T2> executeAssertion
+    )
+    {
+        T1[]? capturedFirst = null;
+        T2? capturedSecond = default;
+
+        Exception ExceptionFactory(ReadOnlySpan<T1> parameter, T2 second)
+        {
+            capturedFirst = parameter.ToArray();
+            capturedSecond = second;
+            return Exception;
+        }
+
+        try
+        {
+            executeAssertion(invalidValue, additionalValue, ExceptionFactory);
+            throw new XunitException("The assertion should have thrown a custom exception at this point.");
+        }
+        catch (ExceptionDummy exception)
+        {
+            exception.Should().BeSameAs(exception);
+            capturedFirst.Should().Equal(invalidValue.ToArray());
+            capturedSecond.Should().Be(additionalValue);
+        }
+    }
+
+    public static void CustomMemoryException<T1, T2>(
+        Memory<T1> invalidValue,
+        T2 additionalValue,
+        Action<Memory<T1>, T2, ReadOnlySpanExceptionFactory<T1, T2>> executeAssertion
+    )
+    {
+        Memory<T1> capturedFirst = default;
+        T2? capturedSecond = default;
+
+        Exception ExceptionFactory(ReadOnlySpan<T1> first, T2 second)
+        {
+            capturedFirst = first.ToArray();
+            capturedSecond = second;
+            return Exception;
+        }
+
+        try
+        {
+            executeAssertion(invalidValue, additionalValue, ExceptionFactory);
+            throw new XunitException("The assertion should have thrown a custom exception at this point.");
+        }
+        catch (ExceptionDummy exception)
+        {
+            exception.Should().BeSameAs(exception);
+            capturedFirst.ToArray().Should().Equal(invalidValue.ToArray());
+            capturedSecond.Should().Be(additionalValue);
+        }
+    }
+
+    public static void CustomMemoryException<T1, T2>(
+        ReadOnlyMemory<T1> invalidValue,
+        T2 additionalValue,
+        Action<ReadOnlyMemory<T1>, T2, ReadOnlySpanExceptionFactory<T1, T2>> executeAssertion
+    )
+    {
+        ReadOnlyMemory<T1> capturedFirst = default;
+        T2? capturedSecond = default;
+
+        Exception ExceptionFactory(ReadOnlySpan<T1> first, T2 second)
+        {
+            capturedFirst = first.ToArray();
+            capturedSecond = second;
+            return Exception;
+        }
+
+        try
+        {
+            executeAssertion(invalidValue, additionalValue, ExceptionFactory);
+            throw new XunitException("The assertion should have thrown a custom exception at this point.");
+        }
+        catch (ExceptionDummy exception)
+        {
+            exception.Should().BeSameAs(exception);
+            capturedFirst.ToArray().Should().Equal(invalidValue.ToArray());
+            capturedSecond.Should().Be(additionalValue);
+        }
+    }
+
+    public static void CustomException<T1, T2, T3>(
+        T1 first,
+        T2 second,
+        T3 third,
+        Action<T1, T2, T3, Func<T1, T2, T3, Exception>> executeAssertion
+    )
     {
         T1? capturedFirst = default;
         T2? capturedSecond = default;
@@ -115,8 +337,9 @@ public static class Test
         }
     }
 
-    private sealed class ExceptionDummy : Exception;
-
-    public static void WriteExceptionTo<T>(this ExceptionAssertions<T> exceptionAssertions, ITestOutputHelper output) where T : Exception =>
+    public static void WriteExceptionTo<T>(this ExceptionAssertions<T> exceptionAssertions, ITestOutputHelper output)
+        where T : Exception =>
         output.WriteLine(exceptionAssertions.Which.ToString());
+
+    private sealed class ExceptionDummy : Exception;
 }

--- a/Code/Light.GuardClauses/Check.IsEmailAddress.cs
+++ b/Code/Light.GuardClauses/Check.IsEmailAddress.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using JetBrains.Annotations;
-using System.Runtime.CompilerServices;
 
 namespace Light.GuardClauses;
 
@@ -10,7 +10,7 @@ public static partial class Check
 {
     /// <summary>
     /// Checks if the specified string is an email address using the default email regular expression
-    /// defined in <see cref="RegularExpressions.EmailRegex"/>.
+    /// defined in <see cref="RegularExpressions.EmailRegex" />.
     /// </summary>
     /// <param name="emailAddress">The string to be checked if it is an email address.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -23,9 +23,79 @@ public static partial class Check
     /// </summary>
     /// <param name="emailAddress">The string to be checked.</param>
     /// <param name="emailAddressPattern">The regular expression that determines whether the input string is an email address.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="emailAddressPattern"/> is null.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="emailAddressPattern" /> is null.</exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [ContractAnnotation("emailAddress:null => false; emailAddressPattern:null => halt")]
     public static bool IsEmailAddress([NotNullWhen(true)] this string? emailAddress, Regex emailAddressPattern) =>
         emailAddress != null && emailAddressPattern.MustNotBeNull(nameof(emailAddressPattern)).IsMatch(emailAddress);
+
+#if NET8_0
+    /// <summary>
+    /// Checks if the specified span is an email address using the default email regular expression
+    /// defined in <see cref="RegularExpressions.EmailRegex" />.
+    /// </summary>
+    /// <param name="emailAddress">The span to be checked.</param>
+    public static bool IsEmailAddress(this Span<char> emailAddress) =>
+        RegularExpressions.EmailRegex.IsMatch(emailAddress);
+
+    /// <summary>
+    /// Checks if the specified span is an email address using the provided regular expression for validation.
+    /// </summary>
+    /// <param name="emailAddress">The span to be checked.</param>
+    /// <param name="emailAddressPattern">The regular expression that determines whether the input string is an email address.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="emailAddressPattern" /> is null.</exception>
+    public static bool IsEmailAddress(this Span<char> emailAddress, Regex emailAddressPattern) =>
+        emailAddressPattern.MustNotBeNull(nameof(emailAddressPattern)).IsMatch(emailAddress);
+
+    /// <summary>
+    /// Checks if the specified span is an email address using the default email regular expression
+    /// defined in <see cref="RegularExpressions.EmailRegex" />.
+    /// </summary>
+    /// <param name="emailAddress">The span to be checked.</param>
+    public static bool IsEmailAddress(this ReadOnlySpan<char> emailAddress) =>
+        RegularExpressions.EmailRegex.IsMatch(emailAddress);
+
+    /// <summary>
+    /// Checks if the specified span is an email address using the provided regular expression for validation.
+    /// </summary>
+    /// <param name="emailAddress">The span to be checked.</param>
+    /// <param name="emailAddressPattern">The regular expression that determines whether the input string is an email address.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="emailAddressPattern" /> is null.</exception>
+    public static bool IsEmailAddress(this ReadOnlySpan<char> emailAddress, Regex emailAddressPattern) =>
+        emailAddressPattern.MustNotBeNull(nameof(emailAddressPattern)).IsMatch(emailAddress);
+    
+    /// <summary>
+    /// Checks if the specified character memory is an email address using the default email regular expression
+    /// defined in <see cref="RegularExpressions.EmailRegex" />.
+    /// </summary>
+    /// <param name="emailAddress">The character memory to be checked.</param>
+    public static bool IsEmailAddress(this Memory<char> emailAddress) =>
+        RegularExpressions.EmailRegex.IsMatch(emailAddress.Span);
+    
+    /// <summary>
+    /// Checks if the specified character memory is an email address using the provided regular expression for validation.
+    /// </summary>
+    /// <param name="emailAddress">The character memory to be checked.</param>
+    /// <param name="emailAddressPattern">The regular expression that determines whether the input string is an email address.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="emailAddressPattern" /> is null.</exception>
+    public static bool IsEmailAddress(this Memory<char> emailAddress, Regex emailAddressPattern) =>
+        emailAddressPattern.MustNotBeNull(nameof(emailAddressPattern)).IsMatch(emailAddress.Span);
+    
+    /// <summary>
+    /// Checks if the specified character memory is an email address using the default email regular expression
+    /// defined in <see cref="RegularExpressions.EmailRegex" />.
+    /// </summary>
+    /// <param name="emailAddress">The character memory to be checked.</param>
+    public static bool IsEmailAddress(this ReadOnlyMemory<char> emailAddress) =>
+        RegularExpressions.EmailRegex.IsMatch(emailAddress.Span);
+    
+    /// <summary>
+    /// Checks if the specified character memory is an email address using the provided regular expression for validation.
+    /// </summary>
+    /// <param name="emailAddress">The character memory to be checked.</param>
+    /// <param name="emailAddressPattern">The regular expression that determines whether the input string is an email address.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="emailAddressPattern" /> is null.</exception>
+    public static bool IsEmailAddress(this ReadOnlyMemory<char> emailAddress, Regex emailAddressPattern) =>
+        emailAddressPattern.MustNotBeNull(nameof(emailAddressPattern)).IsMatch(emailAddress.Span);
+#endif
 }

--- a/Code/Light.GuardClauses/Check.MustBeEmailAddress.cs
+++ b/Code/Light.GuardClauses/Check.MustBeEmailAddress.cs
@@ -107,4 +107,337 @@ public static partial class Check
 
         return parameter;
     }
+
+#if NET8_0
+    /// <summary>
+    /// Ensures that the span represents a valid email address using the default email regular expression
+    /// defined in <see cref="RegularExpressions.EmailRegex" />, or otherwise throws an <see cref="InvalidEmailAddressException" />.
+    /// </summary>
+    /// <param name="parameter">The span that will be validated as an email address.</param>
+    /// <param name="parameterName">The name of the parameter (optional).</param>
+    /// <param name="message">The message that will be passed to the resulting exception (optional).</param>
+    /// <exception cref="InvalidEmailAddressException">Thrown when <paramref name="parameter" /> is no valid email address.</exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ReadOnlySpan<char> MustBeEmailAddress(
+        this ReadOnlySpan<char> parameter,
+        [CallerArgumentExpression("parameter")] string? parameterName = null,
+        string? message = null
+    )
+    {
+        if (!parameter.IsEmailAddress())
+        {
+            Throw.InvalidEmailAddress(parameter, parameterName, message);
+        }
+
+        return parameter;
+    }
+
+    /// <summary>
+    /// Ensures that the span represents a valid email address using the default email regular expression
+    /// defined in <see cref="RegularExpressions.EmailRegex" />, or otherwise throws your custom exception.
+    /// </summary>
+    /// <param name="parameter">The span that will be validated as an email address.</param>
+    /// <param name="exceptionFactory">The delegate that creates your custom exception. A string created from <paramref name="parameter" /> is passed to this delegate.</param>
+    /// <exception cref="Exception">Your custom exception thrown when <paramref name="parameter" /> is no valid email address.</exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ReadOnlySpan<char> MustBeEmailAddress(
+        this ReadOnlySpan<char> parameter,
+        ReadOnlySpanExceptionFactory<char> exceptionFactory
+    )
+    {
+        if (!parameter.IsEmailAddress())
+        {
+            Throw.CustomSpanException(exceptionFactory, parameter);
+        }
+
+        return parameter;
+    }
+
+    /// <summary>
+    /// Ensures that the span represents a valid email address using the provided regular expression,
+    /// or otherwise throws an <see cref="InvalidEmailAddressException" />.
+    /// </summary>
+    /// <param name="parameter">The span that will be validated as an email address.</param>
+    /// <param name="emailAddressPattern">The regular expression that determines if the span represents a valid email.</param>
+    /// <param name="parameterName">The name of the parameter (optional).</param>
+    /// <param name="message">The message that will be passed to the resulting exception (optional).</param>
+    /// <exception cref="InvalidEmailAddressException">Thrown when <paramref name="parameter" /> is no valid email address.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="emailAddressPattern" /> is null.</exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [ContractAnnotation("emailAddressPattern:null => halt")]
+    public static ReadOnlySpan<char> MustBeEmailAddress(
+        this ReadOnlySpan<char> parameter,
+        Regex emailAddressPattern,
+        [CallerArgumentExpression("parameter")] string? parameterName = null,
+        string? message = null
+    )
+    {
+        emailAddressPattern.MustNotBeNull(nameof(emailAddressPattern));
+
+        if (!parameter.IsEmailAddress(emailAddressPattern))
+        {
+            Throw.InvalidEmailAddress(parameter, parameterName, message);
+        }
+
+        return parameter;
+    }
+
+    /// <summary>
+    /// Ensures that the span represents a valid email address using the provided regular expression,
+    /// or otherwise throws your custom exception.
+    /// </summary>
+    /// <param name="parameter">The span that will be validated as an email address.</param>
+    /// <param name="emailAddressPattern">The regular expression that determines if the span represents a valid email.</param>
+    /// <param name="exceptionFactory">The delegate that creates your custom exception. A string created from <paramref name="parameter" /> and <paramref name="emailAddressPattern" /> are passed to this delegate.</param>
+    /// <exception cref="Exception">Your custom exception thrown when <paramref name="parameter" /> is no valid email address or when <paramref name="emailAddressPattern" /> is null.</exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ReadOnlySpan<char> MustBeEmailAddress(
+        this ReadOnlySpan<char> parameter,
+        Regex emailAddressPattern,
+        ReadOnlySpanExceptionFactory<char, Regex> exceptionFactory
+    )
+    {
+        // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract -- caller might have NRTs turned off
+        if (emailAddressPattern is null || !parameter.IsEmailAddress(emailAddressPattern))
+        {
+            Throw.CustomSpanException(exceptionFactory, parameter, emailAddressPattern!);
+        }
+
+        return parameter;
+    }
+
+    /// <summary>
+    /// Ensures that the span represents a valid email address using the default email regular expression
+    /// defined in <see cref="RegularExpressions.EmailRegex" />, or otherwise throws an <see cref="InvalidEmailAddressException" />.
+    /// </summary>
+    /// <param name="parameter">The span that will be validated as an email address.</param>
+    /// <param name="parameterName">The name of the parameter (optional).</param>
+    /// <param name="message">The message that will be passed to the resulting exception (optional).</param>
+    /// <exception cref="InvalidEmailAddressException">Thrown when <paramref name="parameter" /> is no valid email address.</exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Span<char> MustBeEmailAddress(
+        this Span<char> parameter,
+        [CallerArgumentExpression("parameter")] string? parameterName = null,
+        string? message = null
+    )
+    {
+        ((ReadOnlySpan<char>) parameter).MustBeEmailAddress(parameterName, message);
+        return parameter;
+    }
+
+    /// <summary>
+    /// Ensures that the span represents a valid email address using the default email regular expression
+    /// defined in <see cref="RegularExpressions.EmailRegex" />, or otherwise throws your custom exception.
+    /// </summary>
+    /// <param name="parameter">The span that will be validated as an email address.</param>
+    /// <param name="exceptionFactory">The delegate that creates your custom exception. A string created from <paramref name="parameter" /> is passed to this delegate.</param>
+    /// <exception cref="Exception">Your custom exception thrown when <paramref name="parameter" /> is no valid email address.</exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Span<char> MustBeEmailAddress(
+        this Span<char> parameter,
+        ReadOnlySpanExceptionFactory<char> exceptionFactory
+    )
+    {
+        ((ReadOnlySpan<char>) parameter).MustBeEmailAddress(exceptionFactory);
+        return parameter;
+    }
+
+    /// <summary>
+    /// Ensures that the span represents a valid email address using the provided regular expression,
+    /// or otherwise throws an <see cref="InvalidEmailAddressException" />.
+    /// </summary>
+    /// <param name="parameter">The span that will be validated as an email address.</param>
+    /// <param name="emailAddressPattern">The regular expression that determines if the span represents a valid email.</param>
+    /// <param name="parameterName">The name of the parameter (optional).</param>
+    /// <param name="message">The message that will be passed to the resulting exception (optional).</param>
+    /// <exception cref="InvalidEmailAddressException">Thrown when <paramref name="parameter" /> is no valid email address.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="emailAddressPattern" /> is null.</exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [ContractAnnotation("emailAddressPattern:null => halt")]
+    public static Span<char> MustBeEmailAddress(
+        this Span<char> parameter,
+        Regex emailAddressPattern,
+        [CallerArgumentExpression("parameter")] string? parameterName = null,
+        string? message = null
+    )
+    {
+        ((ReadOnlySpan<char>) parameter).MustBeEmailAddress(emailAddressPattern, parameterName, message);
+        return parameter;
+    }
+
+    /// <summary>
+    /// Ensures that the span represents a valid email address using the provided regular expression,
+    /// or otherwise throws your custom exception.
+    /// </summary>
+    /// <param name="parameter">The span that will be validated as an email address.</param>
+    /// <param name="emailAddressPattern">The regular expression that determines if the span represents a valid email.</param>
+    /// <param name="exceptionFactory">The delegate that creates your custom exception. A string created from <paramref name="parameter" /> and <paramref name="emailAddressPattern" /> are passed to this delegate.</param>
+    /// <exception cref="Exception">Your custom exception thrown when <paramref name="parameter" /> is no valid email address or when <paramref name="emailAddressPattern" /> is null.</exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Span<char> MustBeEmailAddress(
+        this Span<char> parameter,
+        Regex emailAddressPattern,
+        ReadOnlySpanExceptionFactory<char, Regex> exceptionFactory
+    )
+    {
+        ((ReadOnlySpan<char>) parameter).MustBeEmailAddress(emailAddressPattern, exceptionFactory);
+        return parameter;
+    }
+
+    /// <summary>
+    /// Ensures that the memory represents a valid email address using the default email regular expression
+    /// defined in <see cref="RegularExpressions.EmailRegex" />, or otherwise throws an <see cref="InvalidEmailAddressException" />.
+    /// </summary>
+    /// <param name="parameter">The memory that will be validated as an email address.</param>
+    /// <param name="parameterName">The name of the parameter (optional).</param>
+    /// <param name="message">The message that will be passed to the resulting exception (optional).</param>
+    /// <exception cref="InvalidEmailAddressException">Thrown when <paramref name="parameter" /> is no valid email address.</exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Memory<char> MustBeEmailAddress(
+        this Memory<char> parameter,
+        [CallerArgumentExpression("parameter")] string? parameterName = null,
+        string? message = null
+    )
+    {
+        ((ReadOnlySpan<char>) parameter.Span).MustBeEmailAddress(parameterName, message);
+        return parameter;
+    }
+
+    /// <summary>
+    /// Ensures that the memory represents a valid email address using the default email regular expression
+    /// defined in <see cref="RegularExpressions.EmailRegex" />, or otherwise throws your custom exception.
+    /// </summary>
+    /// <param name="parameter">The memory that will be validated as an email address.</param>
+    /// <param name="exceptionFactory">The delegate that creates your custom exception. A string created from <paramref name="parameter" /> is passed to this delegate.</param>
+    /// <exception cref="Exception">Your custom exception thrown when <paramref name="parameter" /> is no valid email address.</exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Memory<char> MustBeEmailAddress(
+        this Memory<char> parameter,
+        ReadOnlySpanExceptionFactory<char> exceptionFactory
+    )
+    {
+        ((ReadOnlySpan<char>) parameter.Span).MustBeEmailAddress(exceptionFactory);
+        return parameter;
+    }
+
+    /// <summary>
+    /// Ensures that the memory represents a valid email address using the provided regular expression,
+    /// or otherwise throws an <see cref="InvalidEmailAddressException" />.
+    /// </summary>
+    /// <param name="parameter">The memory that will be validated as an email address.</param>
+    /// <param name="emailAddressPattern">The regular expression that determines if the memory represents a valid email.</param>
+    /// <param name="parameterName">The name of the parameter (optional).</param>
+    /// <param name="message">The message that will be passed to the resulting exception (optional).</param>
+    /// <exception cref="InvalidEmailAddressException">Thrown when <paramref name="parameter" /> is no valid email address.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="emailAddressPattern" /> is null.</exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [ContractAnnotation("emailAddressPattern:null => halt")]
+    public static Memory<char> MustBeEmailAddress(
+        this Memory<char> parameter,
+        Regex emailAddressPattern,
+        [CallerArgumentExpression("parameter")] string? parameterName = null,
+        string? message = null
+    )
+    {
+        ((ReadOnlySpan<char>) parameter.Span).MustBeEmailAddress(emailAddressPattern, parameterName, message);
+        return parameter;
+    }
+
+    /// <summary>
+    /// Ensures that the memory represents a valid email address using the provided regular expression,
+    /// or otherwise throws your custom exception.
+    /// </summary>
+    /// <param name="parameter">The memory that will be validated as an email address.</param>
+    /// <param name="emailAddressPattern">The regular expression that determines if the memory represents a valid email.</param>
+    /// <param name="exceptionFactory">The delegate that creates your custom exception. A string created from <paramref name="parameter" /> and <paramref name="emailAddressPattern" /> are passed to this delegate.</param>
+    /// <exception cref="Exception">Your custom exception thrown when <paramref name="parameter" /> is no valid email address or when <paramref name="emailAddressPattern" /> is null.</exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Memory<char> MustBeEmailAddress(
+        this Memory<char> parameter,
+        Regex emailAddressPattern,
+        ReadOnlySpanExceptionFactory<char, Regex> exceptionFactory
+    )
+    {
+        ((ReadOnlySpan<char>) parameter.Span).MustBeEmailAddress(emailAddressPattern, exceptionFactory);
+        return parameter;
+    }
+
+    /// <summary>
+    /// Ensures that the memory represents a valid email address using the default email regular expression
+    /// defined in <see cref="RegularExpressions.EmailRegex" />, or otherwise throws an <see cref="InvalidEmailAddressException" />.
+    /// </summary>
+    /// <param name="parameter">The memory that will be validated as an email address.</param>
+    /// <param name="parameterName">The name of the parameter (optional).</param>
+    /// <param name="message">The message that will be passed to the resulting exception (optional).</param>
+    /// <exception cref="InvalidEmailAddressException">Thrown when <paramref name="parameter" /> is no valid email address.</exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ReadOnlyMemory<char> MustBeEmailAddress(
+        this ReadOnlyMemory<char> parameter,
+        [CallerArgumentExpression("parameter")] string? parameterName = null,
+        string? message = null
+    )
+    {
+        parameter.Span.MustBeEmailAddress(parameterName, message);
+        return parameter;
+    }
+
+    /// <summary>
+    /// Ensures that the memory represents a valid email address using the default email regular expression
+    /// defined in <see cref="RegularExpressions.EmailRegex" />, or otherwise throws your custom exception.
+    /// </summary>
+    /// <param name="parameter">The memory that will be validated as an email address.</param>
+    /// <param name="exceptionFactory">The delegate that creates your custom exception. A string created from <paramref name="parameter" /> is passed to this delegate.</param>
+    /// <exception cref="Exception">Your custom exception thrown when <paramref name="parameter" /> is no valid email address.</exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ReadOnlyMemory<char> MustBeEmailAddress(
+        this ReadOnlyMemory<char> parameter,
+        ReadOnlySpanExceptionFactory<char> exceptionFactory
+    )
+    {
+        parameter.Span.MustBeEmailAddress(exceptionFactory);
+        return parameter;
+    }
+
+    /// <summary>
+    /// Ensures that the memory represents a valid email address using the provided regular expression,
+    /// or otherwise throws an <see cref="InvalidEmailAddressException" />.
+    /// </summary>
+    /// <param name="parameter">The memory that will be validated as an email address.</param>
+    /// <param name="emailAddressPattern">The regular expression that determines if the memory represents a valid email.</param>
+    /// <param name="parameterName">The name of the parameter (optional).</param>
+    /// <param name="message">The message that will be passed to the resulting exception (optional).</param>
+    /// <exception cref="InvalidEmailAddressException">Thrown when <paramref name="parameter" /> is no valid email address.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="emailAddressPattern" /> is null.</exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [ContractAnnotation("emailAddressPattern:null => halt")]
+    public static ReadOnlyMemory<char> MustBeEmailAddress(
+        this ReadOnlyMemory<char> parameter,
+        Regex emailAddressPattern,
+        [CallerArgumentExpression("parameter")] string? parameterName = null,
+        string? message = null
+    )
+    {
+        parameter.Span.MustBeEmailAddress(emailAddressPattern, parameterName, message);
+        return parameter;
+    }
+
+    /// <summary>
+    /// Ensures that the memory represents a valid email address using the provided regular expression,
+    /// or otherwise throws your custom exception.
+    /// </summary>
+    /// <param name="parameter">The memory that will be validated as an email address.</param>
+    /// <param name="emailAddressPattern">The regular expression that determines if the memory represents a valid email.</param>
+    /// <param name="exceptionFactory">The delegate that creates your custom exception. A string created from <paramref name="parameter" /> and <paramref name="emailAddressPattern" /> are passed to this delegate.</param>
+    /// <exception cref="Exception">Your custom exception thrown when <paramref name="parameter" /> is no valid email address or when <paramref name="emailAddressPattern" /> is null.</exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ReadOnlyMemory<char> MustBeEmailAddress(
+        this ReadOnlyMemory<char> parameter,
+        Regex emailAddressPattern,
+        ReadOnlySpanExceptionFactory<char, Regex> exceptionFactory
+    )
+    {
+        parameter.Span.MustBeEmailAddress(emailAddressPattern, exceptionFactory);
+        return parameter;
+    }
+#endif
 }

--- a/Code/Light.GuardClauses/Exceptions/Throw.cs
+++ b/Code/Light.GuardClauses/Exceptions/Throw.cs
@@ -84,6 +84,14 @@ public static class Throw
     [DoesNotReturn]
     public static void InvalidEmailAddress(string parameter, [CallerArgumentExpression("parameter")] string? parameterName = null, string? message = null) =>
         throw new InvalidEmailAddressException(parameterName, message ?? $"{parameterName ?? "The string"} must be a valid email address, but it actually is \"{parameter}\".");
+    
+    /// <summary>
+    /// Throws an <see cref="InvalidEmailAddressException"/> using the optional message.
+    /// </summary>
+    [ContractAnnotation("=> halt")]
+    [DoesNotReturn]
+    public static void InvalidEmailAddress(ReadOnlySpan<char> parameter, [CallerArgumentExpression("parameter")] string? parameterName = null, string? message = null) =>
+        throw new InvalidEmailAddressException(parameterName, message ?? $"{parameterName ?? "The string"} must be a valid email address, but it actually is \"{parameter.ToString()}\".");
 
     /// <summary>
     /// Throws the default <see cref="NullableHasNoValueException" /> indicating that a <see cref="Nullable{T}" /> has no value, using the optional parameter name and message.

--- a/Code/Light.GuardClauses/RegularExpressions.cs
+++ b/Code/Light.GuardClauses/RegularExpressions.cs
@@ -14,8 +14,9 @@ public static class RegularExpressions
     /// <summary>
     /// Gets the string that represents the <see cref="EmailRegex" />.
     /// </summary>
+    // This is an AI-generated regex. I don't have any clue and I find it way to complex to ever understand it.
     public const string EmailRegexText =
-        @"^[\w!#$%&'*+\-/=?\^_`{|}~]+(\.[\w!#$%&'*+\-/=?\^_`{|}~]+)*@((((\w+\-?)+\.)+[a-zA-Z]{2,4})|(([0-9]{1,3}\.){3}[0-9]{1,3}))$";
+        @"^(?:(?:""(?:(?:[^""\\]|\\.)*)""|[\p{L}\p{N}!#$%&'*+\-/=?^_`{|}~-]+(?:\.[\p{L}\p{N}!#$%&'*+\-/=?^_`{|}~-]+)*)@(?:(?:[A-Za-z0-9](?:[A-Za-z0-9\-]*[A-Za-z0-9])?\.)+[A-Za-z]{2,}|(?:\[(?:IPv6:[0-9A-Fa-f:.]+)\])|(?:25[0-5]|2[0-4]\d|[01]?\d?\d)(?:\.(?:25[0-5]|2[0-4]\d|[01]?\d?\d)){3}))$";
 
     /// <summary>
     /// Gets the default regular expression for email validation.


### PR DESCRIPTION
This pull request introduces significant enhancements to the email validation tests in the `Light.GuardClauses` library. The changes include adding new test data classes for valid and invalid email addresses, expanding the test coverage to include various span types, and refactoring existing tests to use the new test data classes.

### Enhancements to email validation tests:

* [`Code/Light.GuardClauses.Tests/StringAssertions/InvalidEmailAddresses.cs`](diffhunk://#diff-18c3ff11fb099855e40baa58086ebfa4e29ad15bdfc67d933403454079a3f77eR1-R33): Added a new `InvalidEmailAddresses` class to provide test data for invalid email addresses and a subclass `InvalidEmailAddressesWithNull` to include null values.
* [`Code/Light.GuardClauses.Tests/StringAssertions/ValidEmailAddresses.cs`](diffhunk://#diff-ad4f881d5b2cc3b6aab8e71da54333d3001b1c6183290ec5c0dad64d9d0e04fbR1-R28): Added a new `ValidEmailAddresses` class to provide test data for valid email addresses.
* [`Code/Light.GuardClauses.Tests/StringAssertions/IsEmailAddressTests.cs`](diffhunk://#diff-c30707190dcea99ebba21312e6b69febcda455583305e37b45ed5e9a03dfeefcR1-R108): Added comprehensive tests for email validation using `ReadOnlySpan`, `Span`, `Memory`, and `ReadOnlyMemory` types, leveraging the new test data classes.
* [`Code/Light.GuardClauses.Tests/StringAssertions/MustBeEmailAddressTests.cs`](diffhunk://#diff-26d2cde3da722dcbdcd6ed8e26606463bcfeba3098045df87e0d3a21fc6ee8d2L12-R41): Refactored existing tests to use the new `ValidEmailAddresses` and `InvalidEmailAddresses` classes, and added tests for `ReadOnlySpan`, `Span`, `Memory`, and `ReadOnlyMemory` types. [[1]](diffhunk://#diff-26d2cde3da722dcbdcd6ed8e26606463bcfeba3098045df87e0d3a21fc6ee8d2L12-R41) [[2]](diffhunk://#diff-26d2cde3da722dcbdcd6ed8e26606463bcfeba3098045df87e0d3a21fc6ee8d2L58-R59) [[3]](diffhunk://#diff-26d2cde3da722dcbdcd6ed8e26606463bcfeba3098045df87e0d3a21fc6ee8d2L85-R114) [[4]](diffhunk://#diff-26d2cde3da722dcbdcd6ed8e26606463bcfeba3098045df87e0d3a21fc6ee8d2R126-R467)

### Codebase improvements:

* [`Code/Light.GuardClauses.Tests/ExecuteReadOnlySpanAssertion.cs`](diffhunk://#diff-c0de52054cc207b157113b97ca1cc56327a3a813bd386b38dbd89a22cd22ee6eR1-R26): Introduced new delegate types to handle assertions for `ReadOnlySpan` and `Span` types, enhancing code readability and maintainability.

These changes collectively improve the robustness and coverage of the email validation functionality in the `Light.GuardClauses` library.