### PR TITLE
MustNotContain for immutable array

### DIFF
--- a/Code/Light.GuardClauses/Check.MustNotContain.cs
+++ b/Code/Light.GuardClauses/Check.MustNotContain.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
@@ -193,6 +194,53 @@ public static partial class Check
         if (parameter is null || value is null || parameter.IndexOf(value, comparisonType) >= 0)
         {
             Throw.CustomException(exceptionFactory, parameter, value!, comparisonType);
+        }
+
+        return parameter;
+    }
+
+    /// <summary>
+    /// Ensures that the <see cref="ImmutableArray{T}" /> does not contain the specified item, or otherwise throws an <see cref="ExistingItemException" />.
+    /// </summary>
+    /// <param name="parameter">The <see cref="ImmutableArray{T}" /> to be checked.</param>
+    /// <param name="item">The item that must not be part of the <see cref="ImmutableArray{T}" />.</param>
+    /// <param name="parameterName">The name of the parameter (optional).</param>
+    /// <param name="message">The message that will be passed to the resulting exception (optional).</param>
+    /// <exception cref="ExistingItemException">Thrown when <paramref name="parameter" /> contains <paramref name="item" />.</exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ImmutableArray<T> MustNotContain<T>(
+        this ImmutableArray<T> parameter,
+        T item,
+        [CallerArgumentExpression("parameter")] string? parameterName = null,
+        string? message = null
+    )
+    {
+        if (parameter.Contains(item))
+        {
+            Throw.ExistingItem(parameter, item, parameterName, message);
+        }
+
+        return parameter;
+    }
+
+    /// <summary>
+    /// Ensures that the <see cref="ImmutableArray{T}" /> does not contain the specified item, or otherwise throws your custom exception.
+    /// </summary>
+    /// <param name="parameter">The <see cref="ImmutableArray{T}" /> to be checked.</param>
+    /// <param name="item">The item that must not be part of the <see cref="ImmutableArray{T}" />.</param>
+    /// <param name="exceptionFactory">The delegate that creates your custom exception. <paramref name="parameter" /> and <paramref name="item" /> are passed to this delegate.</param>
+    /// <exception cref="Exception">Your custom exception thrown when <paramref name="parameter" /> contains <paramref name="item" />.</exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [ContractAnnotation("exceptionFactory:null => halt")]
+    public static ImmutableArray<T> MustNotContain<T>(
+        this ImmutableArray<T> parameter,
+        T item,
+        Func<ImmutableArray<T>, T, Exception> exceptionFactory
+    )
+    {
+        if (parameter.Contains(item))
+        {
+            Throw.CustomException(exceptionFactory, parameter, item);
         }
 
         return parameter;

--- a/Code/Plans/issue-116-must-not-contain-for-immutable-array.md
+++ b/Code/Plans/issue-116-must-not-contain-for-immutable-array.md
@@ -1,0 +1,20 @@
+# Issue 116 - MustNotContain for ImmutableArray
+
+## Context
+
+The .NET library Light.GuardClauses already has several assertions for collections. They often rely on `IEnumerable<T>` or `IEnumerable`. However, these assertions would result in `ImmutableArray<T>` being boxed - we want to avoid that by providing dedicated assertions for this type which avoids boxing. For this issue, we implement the `MustNotContain` assertion for `ImmutableArray<T>`.
+
+## Tasks for this issue
+
+- [ ] The production code should be placed in the Light.GuardClauses project. The file `Check.MustNotContain.cs` already exists in the root folder of the project - extend this existing file.
+- [ ] In this file, create two extension method overloads called `MustNotContain` for `ImmutableArray<T>`. It should be placed in the class `Check` which is marked as `partial`.
+- [ ] Each assertion in Light.GuardClauses has two overloads - the first one takes the optional `parameterName` and `message` arguments and throw the default exception. The actual exception is thrown in the `Throw` class - use the existing `Throw.ExistingItem` method which is located in `ExceptionFactory/Throw.ExistingItem.cs`.
+- [ ] The other overload takes a delegate which allows the caller to provide their own custom exceptions. Use the existing `Throw.CustomException` method and pass the delegate, the erroneous `ImmutableArray<T>` instance and the unwanted item.
+- [ ] Create unit tests for both overloads. The corresponding tests should be placed in Light.GuardClauses.Tests project, in the existing file 'CollectionAssertions/MustNotContainTests.cs'. Please follow conventions of the existing tests (e.g. use FluentAssertions' `Should()` for assertions).
+
+## Notes
+
+- There are already plenty of other assertions and tests in this library. All overloads are placed in the same file in the production code project. The test projects has top-level folders for different groups of assertions, like `CollectionAssertions`, `StringAssertions`, `DateTimeAssertions` and so on. Please take a look at them to follow a similar structure and code style.
+- This assertion specifically targets `ImmutableArray<T>` to avoid boxing that would occur with generic `IEnumerable<T>` extensions.
+- The assertion should verify that the `ImmutableArray<T>` does not contain the specified item.
+- If you have any questions or suggestions, please ask me about them.


### PR DESCRIPTION
Closes https://github.com/feO2x/Light.GuardClauses/issues/116

This pull request introduces the `MustNotContain` assertion for `ImmutableArray<T>` in the Light.GuardClauses library. The changes include extending the `Check.MustNotContain.cs` file with two new overloads for the `MustNotContain` method, adding corresponding unit tests, and documenting the implementation details in a new issue plan file. Below is a breakdown of the most important changes.

### Feature Addition: `MustNotContain` for `ImmutableArray<T>`

* **Production Code Changes**:
  - Added two overloads of the `MustNotContain` method in `Check.MustNotContain.cs` to ensure `ImmutableArray<T>` does not contain a specified item. The first overload supports optional parameters (`parameterName`, `message`) and throws the default `ExistingItemException`. The second overload allows custom exceptions via a delegate.

* **Unit Tests**:
  - Added multiple unit tests in `MustNotContainTests.cs` to validate the behavior of the new `MustNotContain` methods, including scenarios for items existing, items not existing, empty arrays, custom exceptions, and custom messages.

### Documentation Update

* **Issue Plan**:
  - Created a new issue plan file `issue-116-must-not-contain-for-immutable-array.md` to document the context, tasks, and notes related to implementing `MustNotContain` for `ImmutableArray<T>`. This includes avoiding boxing and adhering to existing library conventions.

### Minor Updates

* **Namespace Import**:
  - Added `System.Collections.Immutable` namespace to both `Check.MustNotContain.cs` and `MustNotContainTests.cs` to support `ImmutableArray<T>`. [[1]](diffhunk://#diff-e01c69fbdb5162778790a9621cbf15d287f4e710c7524873528fab65abb5bc71R3) [[2]](diffhunk://#diff-593ac4c78cfe5b587a5dc83ee2fc26a7e6055262bc4eb09b275e30a6738499f9L1-R3)