### PR TITLE
fix: use NET8_0_OR_GREATER for ifdefs

### DIFF
--- a/Code/Light.GuardClauses.Tests/CommonAssertions/IsApproximatelyTests.cs
+++ b/Code/Light.GuardClauses.Tests/CommonAssertions/IsApproximatelyTests.cs
@@ -41,7 +41,7 @@ public static class IsApproximatelyTests
     public static void FloatWithCustomTolerance(float first, float second, float tolerance, bool expected) =>
         first.IsApproximately(second, tolerance).Should().Be(expected);
 
-#if NET8_0
+#if NET8_0_OR_GREATER
     [Theory]
     [InlineData(1.1, 1.3, 0.5, true)]
     [InlineData(100.55, 100.555, 0.00001, false)]

--- a/Code/Light.GuardClauses.Tests/CommonAssertions/IsGreaterThanOrApproximatelyTests.cs
+++ b/Code/Light.GuardClauses.Tests/CommonAssertions/IsGreaterThanOrApproximatelyTests.cs
@@ -37,7 +37,7 @@ public static class IsGreaterThanOrApproximatelyTests
     public static void FloatWIthCustomTolerance(float first, float second, float tolerance, bool expected) =>
         first.IsGreaterThanOrApproximately(second, tolerance).Should().Be(expected);
 
-#if NET8_0
+#if NET8_0_OR_GREATER
     [Theory]
     [InlineData(15.91, 15.9, 0.1, true)]
     [InlineData(24.449, 24.45, 0.0001, false)]

--- a/Code/Light.GuardClauses.Tests/CommonAssertions/IsLessThanOrApproximatelyTests.cs
+++ b/Code/Light.GuardClauses.Tests/CommonAssertions/IsLessThanOrApproximatelyTests.cs
@@ -37,7 +37,7 @@ public static class IsLessThanOrApproximatelyTests
     public static void FloatWithCustomTolerance(float first, float second, float tolerance, bool expected) =>
         first.IsLessThanOrApproximately(second, tolerance).Should().Be(expected);
 
-#if NET8_0
+#if NET8_0_OR_GREATER
     [Theory]
     [InlineData(13.25, 13.5, 0.1, true)]  // Less than case
     [InlineData(13.5, 13.5, 0.1, true)]   // Equal case

--- a/Code/Light.GuardClauses.Tests/ComparableAssertions/MustBeApproximatelyTests.cs
+++ b/Code/Light.GuardClauses.Tests/ComparableAssertions/MustBeApproximatelyTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using FluentAssertions;
 using Xunit;
 
@@ -178,7 +178,7 @@ public static class MustBeApproximatelyTests
            .WithParameterName(nameof(pi));
     }
 
-#if NET8_0
+#if NET8_0_OR_GREATER
     [Theory]
     [InlineData(5.1, 5.0, 0.2)]
     [InlineData(10.3, 10.3, 0.01)]

--- a/Code/Light.GuardClauses.Tests/ComparableAssertions/MustBeGreaterThanOrApproximatelyTests.cs
+++ b/Code/Light.GuardClauses.Tests/ComparableAssertions/MustBeGreaterThanOrApproximatelyTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using FluentAssertions;
 using Xunit;
 
@@ -202,7 +202,7 @@ public static class CheckMustBeGreaterThanOrApproximatelyTests
            .WithParameterName(nameof(pi));
     }
 
-#if NET8_0
+#if NET8_0_OR_GREATER
     [Theory]
     [InlineData(15.91, 15.9, 0.1)]
     [InlineData(24.4999, 24.45, 0.0001)]

--- a/Code/Light.GuardClauses.Tests/ComparableAssertions/MustBeLessThanOrApproximatelyTests.cs
+++ b/Code/Light.GuardClauses.Tests/ComparableAssertions/MustBeLessThanOrApproximatelyTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using FluentAssertions;
 using Xunit;
 
@@ -202,7 +202,7 @@ public static class MustBeLessThanOrApproximatelyTests
            .WithParameterName(nameof(threePointFive));
     }
 
-#if NET8_0
+#if NET8_0_OR_GREATER
     [Theory]
     [InlineData(15.9, 15.91, 0.1)]
     [InlineData(24.45, 24.4999, 0.0001)]

--- a/Code/Light.GuardClauses.Tests/ComparableAssertions/MustNotBeApproximatelyTests.cs
+++ b/Code/Light.GuardClauses.Tests/ComparableAssertions/MustNotBeApproximatelyTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using FluentAssertions;
 using Xunit;
 
@@ -180,7 +180,7 @@ public static class MustNotBeApproximatelyTests
            .WithParameterName(nameof(pi));
     }
 
-#if NET8_0
+#if NET8_0_OR_GREATER
     [Theory]
     [InlineData(5.3, 5.0, 0.2)]
     [InlineData(10.4, 10.3, 0.01)]

--- a/Code/Light.GuardClauses.Tests/StringAssertions/IsEmailAddressTests.cs
+++ b/Code/Light.GuardClauses.Tests/StringAssertions/IsEmailAddressTests.cs
@@ -24,7 +24,7 @@ public sealed class IsEmailAddressTests
         isValid.Should().BeTrue();
     }
 
-#if NET8_0
+#if NET8_0_OR_GREATER
     [Theory]
     [ClassData(typeof(InvalidEmailAddressesWithNull))]
     public void IsNotValidEmailAddress_ReadOnlySpan(string email)

--- a/Code/Light.GuardClauses.Tests/StringAssertions/MustBeEmailAddressTests.cs
+++ b/Code/Light.GuardClauses.Tests/StringAssertions/MustBeEmailAddressTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Text.RegularExpressions;
 using FluentAssertions;
 using Light.GuardClauses.Exceptions;
@@ -124,7 +124,7 @@ public static class MustBeEmailAddressTests
            .WithParameterName(nameof(email));
     }
 
-#if NET8_0
+#if NET8_0_OR_GREATER
     [Theory]
     [ClassData(typeof(ValidEmailAddresses))]
     public static void ValidEmailAddress_ReadOnlySpan(string email)

--- a/Code/Light.GuardClauses/CallerArgumentExpressionAttribute.cs
+++ b/Code/Light.GuardClauses/CallerArgumentExpressionAttribute.cs
@@ -1,4 +1,4 @@
-﻿#if !NET8_0
+﻿#if !NET8_0_OR_GREATER
 // ReSharper disable once CheckNamespace -- CallerArgumentExpression must be in exactly this namespace
 namespace System.Runtime.CompilerServices;
 

--- a/Code/Light.GuardClauses/Check.DerivesFrom.cs
+++ b/Code/Light.GuardClauses/Check.DerivesFrom.cs
@@ -1,4 +1,4 @@
-#if NET8_0
+﻿#if NET8_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
 #endif
 using System;

--- a/Code/Light.GuardClauses/Check.Implements.cs
+++ b/Code/Light.GuardClauses/Check.Implements.cs
@@ -1,4 +1,4 @@
-#if NET8_0
+﻿#if NET8_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
 #endif
 using System;
@@ -21,7 +21,7 @@ public static partial class Check
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="type" /> or <paramref name="interfaceType" /> is null.</exception>
     [ContractAnnotation("type:null => halt; interfaceType:null => halt")]
     public static bool Implements(
-#if NET8_0
+#if NET8_0_OR_GREATER
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
 #endif
         [NotNull] [ValidatedNotNull] this Type type,
@@ -53,7 +53,7 @@ public static partial class Check
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="type" />, or <paramref name="interfaceType" />, or <paramref name="typeComparer" /> is null.</exception>
     [ContractAnnotation("type:null => halt; interfaceType:null => halt; typeComparer:null => halt")]
     public static bool Implements(
-#if NET8_0
+#if NET8_0_OR_GREATER
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
 #endif
         [NotNull] [ValidatedNotNull] this Type type,

--- a/Code/Light.GuardClauses/Check.InheritsFrom.cs
+++ b/Code/Light.GuardClauses/Check.InheritsFrom.cs
@@ -1,4 +1,4 @@
-#if NET8_0
+﻿#if NET8_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
 #endif
 using System;
@@ -23,7 +23,7 @@ public static partial class Check
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [ContractAnnotation("type:null => halt; baseClassOrInterfaceType:null => halt")]
     public static bool InheritsFrom(
-#if NET8_0
+#if NET8_0_OR_GREATER
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
 #endif
         [NotNull] [ValidatedNotNull] this Type type,
@@ -46,7 +46,7 @@ public static partial class Check
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [ContractAnnotation("type:null => halt; baseClassOrInterfaceType:null => halt; typeComparer:null => halt")]
     public static bool InheritsFrom(
-#if NET8_0
+#if NET8_0_OR_GREATER
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
 #endif
         [NotNull] [ValidatedNotNull] this Type type,

--- a/Code/Light.GuardClauses/Check.IsApproximately.cs
+++ b/Code/Light.GuardClauses/Check.IsApproximately.cs
@@ -1,6 +1,6 @@
-using System;
+﻿using System;
 using System.Runtime.CompilerServices;
-#if NET8_0
+#if NET8_0_OR_GREATER
 using System.Numerics;
 #endif
 
@@ -62,7 +62,7 @@ public static partial class Check
     public static bool IsApproximately(this float value, float other) =>
         Math.Abs(value - other) <= 0.0001f;
 
-#if NET8_0
+#if NET8_0_OR_GREATER
     /// <summary>
     /// Checks if the specified value is approximately the same as the other value, using the given tolerance.
     /// </summary>

--- a/Code/Light.GuardClauses/Check.IsEmailAddress.cs
+++ b/Code/Light.GuardClauses/Check.IsEmailAddress.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
@@ -29,7 +29,7 @@ public static partial class Check
     public static bool IsEmailAddress([NotNullWhen(true)] this string? emailAddress, Regex emailAddressPattern) =>
         emailAddress != null && emailAddressPattern.MustNotBeNull(nameof(emailAddressPattern)).IsMatch(emailAddress);
 
-#if NET8_0
+#if NET8_0_OR_GREATER
     /// <summary>
     /// Checks if the specified span is an email address using the default email regular expression
     /// defined in <see cref="RegularExpressions.EmailRegex" />.

--- a/Code/Light.GuardClauses/Check.IsGreaterThanOrApproximately.cs
+++ b/Code/Light.GuardClauses/Check.IsGreaterThanOrApproximately.cs
@@ -1,5 +1,5 @@
-using System.Runtime.CompilerServices;
-#if NET8_0
+﻿using System.Runtime.CompilerServices;
+#if NET8_0_OR_GREATER
 using System.Numerics;
 #endif
 
@@ -61,7 +61,7 @@ public static partial class Check
     public static bool IsGreaterThanOrApproximately(this float value, float other) =>
         value > other || value.IsApproximately(other);
 
-#if NET8_0
+#if NET8_0_OR_GREATER
     /// <summary>
     /// Checks if the specified value is greater than or approximately the same as the other value, using the given tolerance.
     /// </summary>

--- a/Code/Light.GuardClauses/Check.IsLessThanOrApproximately.cs
+++ b/Code/Light.GuardClauses/Check.IsLessThanOrApproximately.cs
@@ -1,5 +1,5 @@
-using System.Runtime.CompilerServices;
-#if NET8_0
+﻿using System.Runtime.CompilerServices;
+#if NET8_0_OR_GREATER
 using System.Numerics;
 #endif
 
@@ -61,7 +61,7 @@ public static partial class Check
     public static bool IsLessThanOrApproximately(this float value, float other) =>
         value < other || value.IsApproximately(other);
 
-#if NET8_0
+#if NET8_0_OR_GREATER
     /// <summary>
     /// Checks if the specified value is less than or approximately the same as the other value, using the given tolerance.
     /// </summary>

--- a/Code/Light.GuardClauses/Check.IsOpenConstructedGenericType.cs
+++ b/Code/Light.GuardClauses/Check.IsOpenConstructedGenericType.cs
@@ -1,4 +1,4 @@
-#if NET8_0
+﻿#if NET8_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
 #endif
 using System;

--- a/Code/Light.GuardClauses/Check.IsOrDerivesFrom.cs
+++ b/Code/Light.GuardClauses/Check.IsOrDerivesFrom.cs
@@ -1,4 +1,4 @@
-#if NET8_0
+﻿#if NET8_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
 #endif
 using System;

--- a/Code/Light.GuardClauses/Check.IsOrImplements.cs
+++ b/Code/Light.GuardClauses/Check.IsOrImplements.cs
@@ -1,4 +1,4 @@
-#if NET8_0
+﻿#if NET8_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
 #endif
 using System;
@@ -23,7 +23,7 @@ public static partial class Check
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [ContractAnnotation("type:null => halt; otherType:null => halt")]
     public static bool IsOrImplements(
-#if NET8_0
+#if NET8_0_OR_GREATER
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
 #endif
         [NotNull] [ValidatedNotNull] this Type type,
@@ -43,7 +43,7 @@ public static partial class Check
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [ContractAnnotation("type:null => halt; otherType:null => halt")]
     public static bool IsOrImplements(
-#if NET8_0
+#if NET8_0_OR_GREATER
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
 #endif
         [NotNull] [ValidatedNotNull] this Type type,

--- a/Code/Light.GuardClauses/Check.IsOrInheritsFrom.cs
+++ b/Code/Light.GuardClauses/Check.IsOrInheritsFrom.cs
@@ -1,4 +1,4 @@
-#if NET8_0
+﻿#if NET8_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
 #endif
 using System;
@@ -24,7 +24,7 @@ public static partial class Check
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [ContractAnnotation("type:null => halt; otherType:null => halt")]
     public static bool IsOrInheritsFrom(
-#if NET8_0
+#if NET8_0_OR_GREATER
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
 #endif
         [NotNull] [ValidatedNotNull] this Type type,
@@ -44,7 +44,7 @@ public static partial class Check
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [ContractAnnotation("type:null => halt; otherType:null => halt; typeComparer:null => halt")]
     public static bool IsOrInheritsFrom(
-#if NET8_0
+#if NET8_0_OR_GREATER
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
 #endif
         [NotNull] [ValidatedNotNull] this Type type,

--- a/Code/Light.GuardClauses/Check.MustBeApproximately.cs
+++ b/Code/Light.GuardClauses/Check.MustBeApproximately.cs
@@ -1,7 +1,7 @@
-using System;
+﻿using System;
 using System.Runtime.CompilerServices;
 using Light.GuardClauses.ExceptionFactory;
-#if NET8_0
+#if NET8_0_OR_GREATER
 using System.Numerics;
 #endif
 
@@ -232,7 +232,7 @@ public static partial class Check
         return parameter;
     }
 
-#if NET8_0
+#if NET8_0_OR_GREATER
     /// <summary>
     /// Ensures that the specified <paramref name="parameter" /> is approximately equal to the given
     /// <paramref name="other" /> value, or otherwise throws an <see cref="ArgumentOutOfRangeException" />.

--- a/Code/Light.GuardClauses/Check.MustBeEmailAddress.cs
+++ b/Code/Light.GuardClauses/Check.MustBeEmailAddress.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using JetBrains.Annotations;
@@ -109,7 +109,7 @@ public static partial class Check
         return parameter;
     }
 
-#if NET8_0
+#if NET8_0_OR_GREATER
     /// <summary>
     /// Ensures that the span represents a valid email address using the default email regular expression
     /// defined in <see cref="RegularExpressions.EmailRegex" />, or otherwise throws an <see cref="InvalidEmailAddressException" />.

--- a/Code/Light.GuardClauses/Check.MustBeGreaterThanOrApproximately.cs
+++ b/Code/Light.GuardClauses/Check.MustBeGreaterThanOrApproximately.cs
@@ -1,7 +1,7 @@
-using System;
+﻿using System;
 using System.Runtime.CompilerServices;
 using Light.GuardClauses.ExceptionFactory;
-#if NET8_0
+#if NET8_0_OR_GREATER
 using System.Numerics;
 #endif
 
@@ -227,7 +227,7 @@ public static partial class Check
         return parameter;
     }
 
-#if NET8_0
+#if NET8_0_OR_GREATER
     /// <summary>
     /// Ensures that the specified <paramref name="parameter" /> is greater than or approximately equal to the given
     /// <paramref name="other" /> value, or otherwise throws an <see cref="ArgumentOutOfRangeException" />.

--- a/Code/Light.GuardClauses/Check.MustBeLessThanOrApproximately.cs
+++ b/Code/Light.GuardClauses/Check.MustBeLessThanOrApproximately.cs
@@ -1,7 +1,7 @@
-using System;
+﻿using System;
 using System.Runtime.CompilerServices;
 using Light.GuardClauses.ExceptionFactory;
-#if NET8_0
+#if NET8_0_OR_GREATER
 using System.Numerics;
 #endif
 
@@ -227,7 +227,7 @@ public static partial class Check
         return parameter;
     }
 
-#if NET8_0
+#if NET8_0_OR_GREATER
     /// <summary>
     /// Ensures that the specified <paramref name="parameter" /> is less than or approximately equal to the given
     /// <paramref name="other" /> value, or otherwise throws an <see cref="ArgumentOutOfRangeException" />.

--- a/Code/Light.GuardClauses/Check.MustNotBeApproximately.cs
+++ b/Code/Light.GuardClauses/Check.MustNotBeApproximately.cs
@@ -1,7 +1,7 @@
-using System;
+﻿using System;
 using System.Runtime.CompilerServices;
 using Light.GuardClauses.ExceptionFactory;
-#if NET8_0
+#if NET8_0_OR_GREATER
 using System.Numerics;
 #endif
 
@@ -232,7 +232,7 @@ public static partial class Check
         return parameter;
     }
 
-#if NET8_0
+#if NET8_0_OR_GREATER
     /// <summary>
     /// Ensures that the specified <paramref name="parameter" /> is not approximately equal to the given
     /// <paramref name="other" /> value, or otherwise throws an <see cref="ArgumentOutOfRangeException" />.

--- a/Code/Light.GuardClauses/EnumInfo.cs
+++ b/Code/Light.GuardClauses/EnumInfo.cs
@@ -35,7 +35,7 @@ public static class EnumInfo<T> where T : struct, Enum
 
     static EnumInfo()
     {
-#if NET8_0
+#if NET8_0_OR_GREATER
         EnumConstantsArray = Enum.GetValues<T>();
 #else
         EnumConstantsArray = (T[]) Enum.GetValues(typeof(T));

--- a/Code/Light.GuardClauses/Exceptions/AbsoluteUriException.cs
+++ b/Code/Light.GuardClauses/Exceptions/AbsoluteUriException.cs
@@ -16,7 +16,7 @@ public class AbsoluteUriException : UriException
     /// <param name="message">The message of the exception (optional).</param>
     public AbsoluteUriException(string? parameterName = null, string? message = null) : base(parameterName, message) { }
 
-#if !NET8_0
+#if !NET8_0_OR_GREATER
     /// <inheritdoc />
     protected AbsoluteUriException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 #endif

--- a/Code/Light.GuardClauses/Exceptions/ArgumentDefaultException.cs
+++ b/Code/Light.GuardClauses/Exceptions/ArgumentDefaultException.cs
@@ -16,7 +16,7 @@ public class ArgumentDefaultException : ArgumentException
     /// <param name="message">The message of the exception (optional).</param>
     public ArgumentDefaultException(string? parameterName = null, string? message = null) : base(message, parameterName) { }
 
-#if !NET8_0
+#if !NET8_0_OR_GREATER
     /// <inheritdoc />
     protected ArgumentDefaultException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 #endif

--- a/Code/Light.GuardClauses/Exceptions/CollectionException.cs
+++ b/Code/Light.GuardClauses/Exceptions/CollectionException.cs
@@ -16,7 +16,7 @@ public class CollectionException : ArgumentException
     /// <param name="message">The message of the exception (optional).</param>
     public CollectionException(string? parameterName = null, string? message = null) : base(message, parameterName) { }
 
-#if !NET8_0
+#if !NET8_0_OR_GREATER
     /// <inheritdoc />
     protected CollectionException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 #endif

--- a/Code/Light.GuardClauses/Exceptions/EmptyCollectionException.cs
+++ b/Code/Light.GuardClauses/Exceptions/EmptyCollectionException.cs
@@ -16,7 +16,7 @@ public class EmptyCollectionException : InvalidCollectionCountException
     /// <param name="message">The message of the exception (optional).</param>
     public EmptyCollectionException(string? parameterName = null, string? message = null) : base(parameterName, message) { }
 
-#if !NET8_0
+#if !NET8_0_OR_GREATER
     /// <inheritdoc />
     protected EmptyCollectionException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 #endif

--- a/Code/Light.GuardClauses/Exceptions/EmptyGuidException.cs
+++ b/Code/Light.GuardClauses/Exceptions/EmptyGuidException.cs
@@ -16,7 +16,7 @@ public class EmptyGuidException : ArgumentException
     /// <param name="message">The message of the exception (optional).</param>
     public EmptyGuidException(string? parameterName = null, string? message = null) : base(message, parameterName) { }
 
-#if !NET8_0
+#if !NET8_0_OR_GREATER
     /// <inheritdoc />
     protected EmptyGuidException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 #endif

--- a/Code/Light.GuardClauses/Exceptions/EmptyStringException.cs
+++ b/Code/Light.GuardClauses/Exceptions/EmptyStringException.cs
@@ -16,7 +16,7 @@ public class EmptyStringException : StringException
     /// <param name="message">The message of the exception (optional).</param>
     public EmptyStringException(string? parameterName = null, string? message = null) : base(parameterName, message) { }
 
-#if !NET8_0
+#if !NET8_0_OR_GREATER
     /// <inheritdoc />
     protected EmptyStringException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 #endif

--- a/Code/Light.GuardClauses/Exceptions/EnumValueNotDefinedException.cs
+++ b/Code/Light.GuardClauses/Exceptions/EnumValueNotDefinedException.cs
@@ -16,7 +16,7 @@ public class EnumValueNotDefinedException : ArgumentException
     /// <param name="message">The message of the exception.</param>
     public EnumValueNotDefinedException(string? parameterName = null, string? message = null) : base(message, parameterName) { }
 
-#if !NET8_0
+#if !NET8_0_OR_GREATER
     /// <inheritdoc />
     protected EnumValueNotDefinedException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 #endif

--- a/Code/Light.GuardClauses/Exceptions/ExistingItemException.cs
+++ b/Code/Light.GuardClauses/Exceptions/ExistingItemException.cs
@@ -16,7 +16,7 @@ public class ExistingItemException : CollectionException
     /// <param name="message">The message of the exception (optional).</param>
     public ExistingItemException(string? parameterName = null, string? message = null) : base(parameterName, message) { }
 
-#if !NET8_0
+#if !NET8_0_OR_GREATER
     /// <inheritdoc />
     protected ExistingItemException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 #endif

--- a/Code/Light.GuardClauses/Exceptions/InvalidCollectionCountException.cs
+++ b/Code/Light.GuardClauses/Exceptions/InvalidCollectionCountException.cs
@@ -16,7 +16,7 @@ public class InvalidCollectionCountException : CollectionException
     /// <param name="message">The message of the exception (optional).</param>
     public InvalidCollectionCountException(string? parameterName = null, string? message = null) : base(parameterName, message) { }
 
-#if !NET8_0
+#if !NET8_0_OR_GREATER
     /// <inheritdoc />
     protected InvalidCollectionCountException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 #endif

--- a/Code/Light.GuardClauses/Exceptions/InvalidConfigurationException.cs
+++ b/Code/Light.GuardClauses/Exceptions/InvalidConfigurationException.cs
@@ -16,7 +16,7 @@ public class InvalidConfigurationException : Exception
     /// <param name="innerException">The exception that is the cause of this one (optional).</param>
     public InvalidConfigurationException(string? message = null, Exception? innerException = null) : base(message, innerException) { }
 
-#if !NET8_0
+#if !NET8_0_OR_GREATER
     /// <inheritdoc />
     protected InvalidConfigurationException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 #endif

--- a/Code/Light.GuardClauses/Exceptions/InvalidDateTimeException.cs
+++ b/Code/Light.GuardClauses/Exceptions/InvalidDateTimeException.cs
@@ -16,7 +16,7 @@ public class InvalidDateTimeException : ArgumentException
     /// <param name="message">The message of the exception (optional).</param>
     public InvalidDateTimeException(string? parameterName = null, string? message = null) : base(message, parameterName) { }
 
-#if !NET8_0
+#if !NET8_0_OR_GREATER
     /// <inheritdoc />
     protected InvalidDateTimeException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 #endif

--- a/Code/Light.GuardClauses/Exceptions/InvalidEmailAddressException.cs
+++ b/Code/Light.GuardClauses/Exceptions/InvalidEmailAddressException.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Runtime.Serialization;
 
 namespace Light.GuardClauses.Exceptions;
@@ -16,7 +16,7 @@ public class InvalidEmailAddressException : StringException
     /// <param name="message">The message of the exception (optional).</param>
     public InvalidEmailAddressException(string? parameterName = null, string? message = null) : base(parameterName, message) { }
 
-#if !NET8_0
+#if !NET8_0_OR_GREATER
     /// <inheritdoc />
     protected InvalidEmailAddressException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 #endif

--- a/Code/Light.GuardClauses/Exceptions/InvalidStateException.cs
+++ b/Code/Light.GuardClauses/Exceptions/InvalidStateException.cs
@@ -16,7 +16,7 @@ public class InvalidStateException : Exception
     /// <param name="innerException">The exception that is the cause of this one (optional).</param>
     public InvalidStateException(string? message = null, Exception? innerException = null) : base(message, innerException) { }
 
-#if !NET8_0
+#if !NET8_0_OR_GREATER
     /// <inheritdoc />
     protected InvalidStateException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 #endif

--- a/Code/Light.GuardClauses/Exceptions/InvalidUriSchemeException.cs
+++ b/Code/Light.GuardClauses/Exceptions/InvalidUriSchemeException.cs
@@ -16,7 +16,7 @@ public class InvalidUriSchemeException : UriException
     /// <param name="message">The message of the exception (optional).</param>
     public InvalidUriSchemeException(string? parameterName = null, string? message = null) : base(parameterName, message) { }
 
-#if !NET8_0
+#if !NET8_0_OR_GREATER
     /// <inheritdoc />
     protected InvalidUriSchemeException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 #endif

--- a/Code/Light.GuardClauses/Exceptions/MissingItemException.cs
+++ b/Code/Light.GuardClauses/Exceptions/MissingItemException.cs
@@ -16,7 +16,7 @@ public class MissingItemException : CollectionException
     /// <param name="message">The message of the exception (optional).</param>
     public MissingItemException(string? parameterName = null, string? message = null) : base(parameterName, message) { }
 
-#if !NET8_0
+#if !NET8_0_OR_GREATER
     /// <inheritdoc />
     protected MissingItemException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 #endif

--- a/Code/Light.GuardClauses/Exceptions/NullableHasNoValueException.cs
+++ b/Code/Light.GuardClauses/Exceptions/NullableHasNoValueException.cs
@@ -16,7 +16,7 @@ public class NullableHasNoValueException : ArgumentException
     /// <param name="message">The message of the exception (optional).</param>
     public NullableHasNoValueException(string? parameterName = null, string? message = null) : base(message, parameterName) { }
 
-#if !NET8_0
+#if !NET8_0_OR_GREATER
     /// <inheritdoc />
     protected NullableHasNoValueException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 #endif

--- a/Code/Light.GuardClauses/Exceptions/RelativeUriException.cs
+++ b/Code/Light.GuardClauses/Exceptions/RelativeUriException.cs
@@ -16,7 +16,7 @@ public class RelativeUriException : UriException
     /// <param name="message">The message of the exception (optional).</param>
     public RelativeUriException(string? parameterName = null, string? message = null) : base(parameterName, message) { }
 
-#if !NET8_0
+#if !NET8_0_OR_GREATER
     /// <inheritdoc />
     protected RelativeUriException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 #endif

--- a/Code/Light.GuardClauses/Exceptions/SameObjectReferenceException.cs
+++ b/Code/Light.GuardClauses/Exceptions/SameObjectReferenceException.cs
@@ -16,7 +16,7 @@ public class SameObjectReferenceException : ArgumentException
     /// <param name="message">The message of the exception (optional).</param>
     public SameObjectReferenceException(string? parameterName = null, string? message = null) : base(message, parameterName) { }
 
-#if !NET8_0
+#if !NET8_0_OR_GREATER
     /// <inheritdoc />
     protected SameObjectReferenceException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 #endif

--- a/Code/Light.GuardClauses/Exceptions/StringDoesNotMatchException.cs
+++ b/Code/Light.GuardClauses/Exceptions/StringDoesNotMatchException.cs
@@ -16,7 +16,7 @@ public class StringDoesNotMatchException : StringException
     /// <param name="message">The message of the exception (optional).</param>
     public StringDoesNotMatchException(string? parameterName = null, string? message = null) : base(parameterName, message) { }
 
-#if !NET8_0
+#if !NET8_0_OR_GREATER
     /// <inheritdoc />
     protected StringDoesNotMatchException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 #endif

--- a/Code/Light.GuardClauses/Exceptions/StringException.cs
+++ b/Code/Light.GuardClauses/Exceptions/StringException.cs
@@ -16,7 +16,7 @@ public class StringException : ArgumentException
     /// <param name="message">The message of the exception (optional).</param>
     public StringException(string? parameterName = null, string? message = null) : base(message, parameterName) { }
 
-#if !NET8_0
+#if !NET8_0_OR_GREATER
     /// <inheritdoc />
     protected StringException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 #endif

--- a/Code/Light.GuardClauses/Exceptions/StringLengthException.cs
+++ b/Code/Light.GuardClauses/Exceptions/StringLengthException.cs
@@ -16,7 +16,7 @@ public class StringLengthException : StringException
     /// <param name="message">The message of the exception (optional).</param>
     public StringLengthException(string? parameterName = null, string? message = null) : base(parameterName, message) { }
 
-#if !NET8_0
+#if !NET8_0_OR_GREATER
     /// <inheritdoc />
     protected StringLengthException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 #endif

--- a/Code/Light.GuardClauses/Exceptions/SubstringException.cs
+++ b/Code/Light.GuardClauses/Exceptions/SubstringException.cs
@@ -16,7 +16,7 @@ public class SubstringException : StringException
     /// <param name="message">The message of the exception (optional).</param>
     public SubstringException(string? parameterName = null, string? message = null) : base(parameterName, message) { }
 
-#if !NET8_0
+#if !NET8_0_OR_GREATER
     /// <inheritdoc />
     protected SubstringException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 #endif

--- a/Code/Light.GuardClauses/Exceptions/TypeCastException.cs
+++ b/Code/Light.GuardClauses/Exceptions/TypeCastException.cs
@@ -16,7 +16,7 @@ public class TypeCastException : ArgumentException
     /// <param name="message">The message of the exception (optional).</param>
     public TypeCastException(string? parameterName = null, string? message = null) : base(message, parameterName) { }
 
-#if !NET8_0
+#if !NET8_0_OR_GREATER
     /// <inheritdoc />
     protected TypeCastException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 #endif

--- a/Code/Light.GuardClauses/Exceptions/UriException.cs
+++ b/Code/Light.GuardClauses/Exceptions/UriException.cs
@@ -16,7 +16,7 @@ public class UriException : ArgumentException
     /// <param name="message">The message of the exception (optional).</param>
     public UriException(string? parameterName = null, string? message = null) : base(message, parameterName) { }
 
-#if !NET8_0
+#if !NET8_0_OR_GREATER
     /// <inheritdoc />
     protected UriException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 #endif

--- a/Code/Light.GuardClauses/Exceptions/ValueIsNotOneOfException.cs
+++ b/Code/Light.GuardClauses/Exceptions/ValueIsNotOneOfException.cs
@@ -16,7 +16,7 @@ public class ValueIsNotOneOfException : ArgumentException
     /// <param name="message">The message of the exception (optional).</param>
     public ValueIsNotOneOfException(string? parameterName = null, string? message = null) : base(message, parameterName) { }
 
-#if !NET8_0
+#if !NET8_0_OR_GREATER
     /// <inheritdoc />
     protected ValueIsNotOneOfException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 #endif

--- a/Code/Light.GuardClauses/Exceptions/ValueIsOneOfException.cs
+++ b/Code/Light.GuardClauses/Exceptions/ValueIsOneOfException.cs
@@ -16,7 +16,7 @@ public class ValueIsOneOfException : ArgumentException
     /// <param name="message">The message of the exception (optional).</param>
     public ValueIsOneOfException(string? parameterName = null, string? message = null) : base(message, parameterName) { }
 
-#if !NET8_0
+#if !NET8_0_OR_GREATER
     /// <inheritdoc />
     protected ValueIsOneOfException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 #endif

--- a/Code/Light.GuardClauses/Exceptions/ValuesEqualException.cs
+++ b/Code/Light.GuardClauses/Exceptions/ValuesEqualException.cs
@@ -16,7 +16,7 @@ public class ValuesEqualException : ArgumentException
     /// <param name="message">The message of the exception (optional).</param>
     public ValuesEqualException(string? parameterName = null, string? message = null) : base(message, parameterName) { }
 
-#if !NET8_0
+#if !NET8_0_OR_GREATER
     /// <inheritdoc />
     protected ValuesEqualException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 #endif

--- a/Code/Light.GuardClauses/Exceptions/ValuesNotEqualException.cs
+++ b/Code/Light.GuardClauses/Exceptions/ValuesNotEqualException.cs
@@ -16,7 +16,7 @@ public class ValuesNotEqualException : ArgumentException
     /// <param name="message">The message of the exception (optional).</param>
     public ValuesNotEqualException(string? parameterName = null, string? message = null) : base(message, parameterName) { }
 
-#if !NET8_0
+#if !NET8_0_OR_GREATER
     /// <inheritdoc />
     protected ValuesNotEqualException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 #endif

--- a/Code/Light.GuardClauses/Exceptions/WhiteSpaceStringException.cs
+++ b/Code/Light.GuardClauses/Exceptions/WhiteSpaceStringException.cs
@@ -16,7 +16,7 @@ public class WhiteSpaceStringException : StringException
     /// <param name="message">The message of the exception (optional).</param>
     public WhiteSpaceStringException(string? parameterName = null, string? message = null) : base(parameterName, message) { }
 
-#if !NET8_0
+#if !NET8_0_OR_GREATER
     /// <inheritdoc />
     protected WhiteSpaceStringException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 #endif

--- a/Code/Light.GuardClauses/RegularExpressions.cs
+++ b/Code/Light.GuardClauses/RegularExpressions.cs
@@ -5,7 +5,7 @@ namespace Light.GuardClauses;
 /// <summary>
 /// Provides regular expressions that are used in string assertions.
 /// </summary>
-#if NET8_0
+#if NET8_0_OR_GREATER
 public static partial class RegularExpressions
 #else
 public static class RegularExpressions
@@ -24,7 +24,7 @@ public static class RegularExpressions
     /// was modified to satisfy all tests of https://blogs.msdn.microsoft.com/testing123/2009/02/06/email-address-test-cases/.
     /// </summary>
     public static readonly Regex EmailRegex =
-#if NET8_0
+#if NET8_0_OR_GREATER
         GenerateEmailRegex();
 
     [GeneratedRegex(EmailRegexText, RegexOptions.ECMAScript | RegexOptions.CultureInvariant)]


### PR DESCRIPTION
This allows one to use the SingleFile when targeting .NET 9 or 10, and still getting the .NET 8.0+ enhancements.

I have tested this against .NET 6 - 10, as well as .NET Framework 4.6.2 - 4.8.1.

```xml
<Project>
  <PropertyGroup>
    <TargetFrameworks>net462;net47;net471;net472;net48;net481;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
  </PropertyGroup>
</Project>
```